### PR TITLE
[INJIMOB-2265] add a new endpoint presentation_definition_uri to return the full presentation_definition object when called

### DIFF
--- a/openid4vp-service/README.md
+++ b/openid4vp-service/README.md
@@ -20,9 +20,11 @@ node app.js // execute this command in the openid4vp-service folder
   end-point where we would like to receive the response. Here Localhost won't be accessible from the
   physical device, recommended using ngrok [https://ngrok.com/docs/getting-started/] to generate a
   corresponding mapping url for the Localhost.
+- As part of the Authorization Request Verifier can send **presentation_definition_uri** instead of the full **presentation_definition** to reduce the amount of data embedded in the QR code and this uri returns the actual **presentation_definition** object when called and only one of **presentation_definition** & **presentation_definition_uri** should be present in the request.
 
 **Ex:**
 
+##### Send _presentation_definition_ in request:
 ```javascript
     const authorizationRequest =
     "https://client.example.org/universal-link?
@@ -32,6 +34,26 @@ node app.js // execute this command in the openid4vp-service folder
     &client_id_scheme=redirect_uri
     &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
     &presentation_definition=...
+    &nonce=n-0S6_WzA2Mj
+    &response_uri=ngrokUrl+"/verifier/vp-response"
+    &client_metadata=%7B%22vp_formats%22:%7B%22jwt_vp_json%22:%
+    7B%22alg%22:%5B%22EdDSA%22,%22ES256K%22%5D%7D,%22ldp
+    _vp%22:%7B%22proof_type%22:%5B%22Ed25519Signature201
+    8%22%5D%7D%7D%7D"
+```
+
+or
+
+##### Send _presentation_definition_uri_ in request:
+```javascript
+    const authorizationRequest =
+    "https://client.example.org/universal-link?
+    response_type=vp_token
+    &response_mode=direct_post
+    &client_id=https%3A%2F%2Fclient.example.org%2Fcb
+    &client_id_scheme=redirect_uri
+    &redirect_uri=https%3A%2F%2Fclient.example.org%2Fcb
+    &presentation_definition_uri=ngrokUrl+"/verifier/presentation_definition_uri"
     &nonce=n-0S6_WzA2Mj
     &response_uri=ngrokUrl+"/verifier/vp-response"
     &client_metadata=%7B%22vp_formats%22:%7B%22jwt_vp_json%22:%

--- a/openid4vp-service/README.md
+++ b/openid4vp-service/README.md
@@ -61,8 +61,11 @@ or
     _vp%22:%7B%22proof_type%22:%5B%22Ed25519Signature201
     8%22%5D%7D%7D%7D"
 ```
+### 2. /verifier/presentation_definition_uri:
+- This end-point can be passed as part of the Verifier's Authorization Request QR code which gives the actual presentation_definition object when called.
+- Please refer to the above example to understand how to send presentation_definition_uri as part of the Authorization Request.
 
-### 2. /verifier/vp-response:
+### 3. /verifier/vp-response:
 
 - This is the response_uri end-point which is used to listen to the Verifiable Presentation response
   shared by the wallet and return the response back to the wallet to notify whether this server has

--- a/openid4vp-service/app.js
+++ b/openid4vp-service/app.js
@@ -23,6 +23,8 @@ app.get('/verifier/generate-auth-request-qr', async (req, res) => {
     nonce = crypto.randomBytes(16).toString('base64');
     state = crypto.randomBytes(16).toString('base64');
 
+    //To send presentation_definition_uri instead of presentation_definition replace the presentation_definition with the below presentation_definition_uri in the Authorization request
+    //presentation_definition_uri=https://6671-2405-201-c058-b814-3935-591-c028-f58e.ngrok-free.app/verifier/presentation_definition_uri
     const authorizationRequest = `client_id=https://injiverify.dev1.mosip.net&presentation_definition=${presentation_definition}&response_type=vp_token&response_mode=direct_post&nonce=${nonce}&state=${state}&response_uri=https://f0c2-2405-201-c058-b814-f1e4-f5de-f8a0-abbd.ngrok-free.app/verifier/vp-response&client_metadata=${client_metadata}`;
     const qrCodeData = await QRCode.toDataURL(
       'openid4vp://authorize?' + btoa(authorizationRequest)
@@ -33,6 +35,10 @@ app.get('/verifier/generate-auth-request-qr', async (req, res) => {
     console.error('Error generating QR code:', error);
     res.status(500).send('Internal Server Error');
   }
+});
+
+app.get('/verifier/presentation_definition_uri', async (req, res) => {
+  res.send(presentationDefinition);
 });
 
 app.post('/verifier/vp-response', (req, res) => {

--- a/openid4vp-service/app.js
+++ b/openid4vp-service/app.js
@@ -19,7 +19,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.get('/verifier/generate-auth-request-qr', async (req, res) => {
   try {
     const presentation_definition = JSON.stringify(presentationDefinition);
-    const client_metadata = JSON.stringify({ 'name': 'Requester name' });
+    const client_metadata = JSON.stringify({ 'client_name': 'Requester name' });
     nonce = crypto.randomBytes(16).toString('base64');
     state = crypto.randomBytes(16).toString('base64');
 


### PR DESCRIPTION
- Added a new endpoint **presentation_definition_uri** which returns the full **presentation_definition** object when called instead of embedding it directly into Authorization Request which increases the size of the QR code.