### PR TITLE
INJIMOB-3490: Added Draft 21 QR code support alongside Draft 23 in OpenID4VP mock UI 

### DIFF
--- a/openid4vp-service/app.js
+++ b/openid4vp-service/app.js
@@ -81,6 +81,72 @@ app.get('/verifier/generate-auth-request-by-reference-qr', async (req, res) => {
     }
 });
 
+// Draft 21 endpoints
+app.get('/verifier/generate-auth-request-by-value-redirect-qr-draft21', async (req, res) => {
+    try {
+        const qrData = createUrlWithParams(redirectAuthorizationRequestDraft21);
+        const qrCodeData = await QRCode.toDataURL(qrData);
+        const inputData = redirectAuthorizationRequestDraft21
+        res.json({ qrCodeData, qrData, inputData });
+    } catch (error) {
+        console.error('Error generating QR code:', error);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+app.get('/verifier/generate-auth-request-by-value-pre-registered-qr-draft21', async (req, res) => {
+    try {
+        const qrData = createUrlWithParams(preRegisteredAuthorizationRequestDraft21);
+        const qrCodeData = await QRCode.toDataURL(qrData);
+        const inputData = preRegisteredAuthorizationRequestDraft21
+        res.json({ qrCodeData, qrData, inputData });
+    } catch (error) {
+        console.error('Error generating QR code:', error);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+app.get('/verifier/generate-auth-request-by-reference-qr-draft21', async (req, res) => {
+    try {
+        const qrData = createUrlWithParams(authorizationRequestParamsDraft21);
+        const qrCodeData = await QRCode.toDataURL(qrData);
+        const inputData = authorizationRequestParamsDraft21
+        res.json({ qrCodeData, qrData, inputData });
+    } catch (error) {
+        console.error('Error generating QR code:', error);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+app.get('/verifier/get-auth-request-obj-draft21', async (req, res) => {
+    try {
+        const jwt = await createJWT(didAuthorizationRequestDraft21)
+        res.contentType("application/oauth-authz-req+jwt")
+        res.send(jwt)
+
+    } catch (error) {
+        console.error('Error generating JWT :', error);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+app.post('/verifier/get-auth-request-obj-draft21', async (req, res) => {
+    try {
+        console.info("Received request with request body:", req.body);
+        const walletNonce = req.body?.wallet_nonce;
+        const jwt = walletNonce
+            ? await createJWT({ ...didAuthorizationRequestDraft21, wallet_nonce: walletNonce })
+            : await createJWT(didAuthorizationRequestDraft21);
+        res.contentType("application/oauth-authz-req+jwt");
+        res.send(jwt);
+        //res.send(btoa(JSON.stringify(didAuthorizationRequestDraft21)))
+
+    }  catch (error) {
+        console.error('Error generating JWT :', error);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
 app.get('/verifier/get-auth-request-obj', async (req, res) => {
     try {
         const jwt = await createJWT(didAuthorizationRequest)

--- a/openid4vp-service/constants.js
+++ b/openid4vp-service/constants.js
@@ -3,8 +3,9 @@ const crypto = require('crypto');
 const ed25519PublicKey = "IKXhA7W1HD1sAl+OfG59VKAqciWrrOL1Rw5F+PGLhi4="
 const ed25519PrivateKey = "7JGq310it2uq1_KZ3kARpoUB36KaVO2Ki5VeqQ_856A"
 //update this baseurl with the localtunnel url
-const baseUrl = "<local-tunnel url>"
+const baseUrl = "<local-tunnel-url>"
 const requestUri = `${baseUrl}/verifier/get-auth-request-obj`
+const requestUriDraft21 = `${baseUrl}/verifier/get-auth-request-obj-draft21`; //draft-21
 const responseUri = `${baseUrl}/verifier/vp-response`
 const presentationDefinitionUri  = `${baseUrl}/verifier/presentation_definition_uri`
 const didDocumentUrl = "did:web:mosip.github.io:inji-mock-services:openid4vp-service:docs"
@@ -20,6 +21,7 @@ module.exports = {
     ed25519PublicKey,
     ed25519PrivateKey,
     requestUri,
+    requestUriDraft21,
     responseUri,
     didDocumentUrl,
     publicKeyId,

--- a/openid4vp-service/inputData.js
+++ b/openid4vp-service/inputData.js
@@ -1,4 +1,4 @@
-const {nonce, state, responseUri, baseUrl, didDocumentUrl, requestUri, clientId, presentationDefinitionUri} = require("./constants");
+const {nonce, state, responseUri, baseUrl, didDocumentUrl, requestUri, requestUriDraft21, clientId, presentationDefinitionUri} = require("./constants");
 const clientMetadata = require('./clientMetadataMock.json');
 
 const client_metadata = JSON.stringify(clientMetadata);
@@ -37,7 +37,7 @@ const redirectAuthorizationRequestDraft23 = {
     "client_metadata": client_metadata,
 }
 
-const redirectAuthorizationRequestDrat21 = {
+const redirectAuthorizationRequestDraft21 = {
     "client_id": responseUri,
     "client_id_scheme": "redirect_uri",
     "presentation_definition_uri": presentationDefinitionUri,
@@ -81,7 +81,7 @@ const authorizationRequestParamsDraft23 = {
 const authorizationRequestParamsDraft21 = {
     "client_id":didDocumentUrl,
     "client_id_scheme": "did",
-    "request_uri": requestUri,
+    "request_uri": requestUriDraft21,
     "request_uri_method": "post"
 }
 
@@ -93,7 +93,7 @@ module.exports = {
     authorizationRequestParams: authorizationRequestParamsDraft23,
     preRegisteredAuthorizationRequestDraft21: preRegisteredAuthorizationRequestDraft21,
     didAuthorizationRequestDraft21: didAuthorizationRequestDraft21,
-    redirectAuthorizationRequestDraft21: redirectAuthorizationRequestDrat21,
+    redirectAuthorizationRequestDraft21: redirectAuthorizationRequestDraft21,
     authorizationRequestParamsDraft21: authorizationRequestParamsDraft21
 }
 

--- a/openid4vp-service/ovp-client/src/Home.js
+++ b/openid4vp-service/ovp-client/src/Home.js
@@ -1,42 +1,104 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-
 
 const Home = () => {
     const navigate = useNavigate();
+    const [selectedEndpoint, setSelectedEndpoint] = useState(null);
 
     useEffect(() => {
         document.title = 'Home';
     }, []);
 
     const endpoints = [
-        { name: "By value - Redirect", path: "/verifier/generate-auth-request-by-value-redirect-qr" },
-        { name: "By value - Pre-Registered", path: "/verifier/generate-auth-request-by-value-pre-registered-qr" },
-        { name: "By Reference", path: "/verifier/generate-auth-request-by-reference-qr" },
+        { 
+            name: "By value - Redirect", 
+            draft23Path: "/verifier/generate-auth-request-by-value-redirect-qr",
+            draft21Path: "/verifier/generate-auth-request-by-value-redirect-qr-draft21"
+        },
+        { 
+            name: "By value - Pre-Registered", 
+            draft23Path: "/verifier/generate-auth-request-by-value-pre-registered-qr",
+            draft21Path: "/verifier/generate-auth-request-by-value-pre-registered-qr-draft21"
+        },
+        { 
+            name: "By Reference", 
+            draft23Path: "/verifier/generate-auth-request-by-reference-qr",
+            draft21Path: "/verifier/generate-auth-request-by-reference-qr-draft21"
+        },
     ];
 
     const handleClick = (endpointObj) => {
-        navigate('/qr', { state: { endpoint: endpointObj.path, name: endpointObj.name } });
+        setSelectedEndpoint(endpointObj);
+    };
+
+    const handleDraftClick = (draft, path) => {
+        navigate('/qr', { 
+            state: { 
+                endpoint: path, 
+                name: `${selectedEndpoint.name} - ${draft}`,
+                draft: draft
+            } 
+        });
+    };
+
+    const handleBack = () => {
+        setSelectedEndpoint(null);
     };
 
     return (
         <div className="homepage-container">
-            <h1 className="page-title">Home screen</h1>
-            <h2>Select Auth Request Type</h2>
-            <div className="auth-button-list">
-                {endpoints.map(e => (
+            {!selectedEndpoint ? (
+                <>
+                    <h1 style={{marginBottom: '20px'}}>Home screen</h1>
+                    <h2>Select Auth Request Type</h2>
+                    <div className="auth-button-list">
+                        {endpoints.map(e => (
+                            <button
+                                key={e.name}
+                                onClick={() => handleClick(e)}
+                                className="auth-request-button"
+                            >
+                                {e.name}
+                            </button>
+                        ))}
+                    </div>
+                </>
+            ) : (
+                <>
                     <button
-                        key={e.name}
-                        onClick={() => handleClick(e)}
-                        className="auth-request-button"
-                        onMouseEnter={e => e.target.style.backgroundColor = '#e0e0e0'}
-                        onMouseLeave={e => e.target.style.backgroundColor = '#f0f0f0'}
+                        onClick={handleBack}
+                        style={{
+                            marginBottom: '20px',
+                            padding: '8px 16px',
+                            fontSize: '14px',
+                            borderRadius: '4px',
+                            border: '1px solid #ccc',
+                            background: '#f8f8f8',
+                            cursor: 'pointer',
+                        }}
                     >
-                        {e.name}
+                        ← Back
                     </button>
-                ))}
-            </div>
+                    <h1 style={{ marginBottom: '20px' }}>Select OpenID4VP Draft Version</h1>
+                    <h2 style={{ marginBottom: '20px', color: '#666' }}>{selectedEndpoint.name}</h2>
+                    
+                    <div className="auth-button-list">
+                        <button
+                            onClick={() => handleDraftClick('Draft 23', selectedEndpoint.draft23Path)}
+                            className="auth-request-button"
+                        >
+                            Draft 23
+                        </button>
+
+                        <button
+                            onClick={() => handleDraftClick('Draft 21', selectedEndpoint.draft21Path)}
+                            className="auth-request-button"
+                        >
+                            Draft 21
+                        </button>
+                    </div>
+                </>
+            )}
         </div>
     );
 };

--- a/openid4vp-service/ovp-client/src/Home.js
+++ b/openid4vp-service/ovp-client/src/Home.js
@@ -21,25 +21,15 @@ const Home = () => {
     };
 
     return (
-        <div style={{paddingLeft: '40px', paddingTop: '20px'}}>
-            <h1 style={{marginBottom: '20px'}}>Home screen</h1>
+        <div className="homepage-container">
+            <h1 className="page-title">Home screen</h1>
             <h2>Select Auth Request Type</h2>
-            <div style={{display: 'flex', flexDirection: 'column', gap: '12px', marginTop: '10px'}}>
+            <div className="auth-button-list">
                 {endpoints.map(e => (
                     <button
                         key={e.name}
                         onClick={() => handleClick(e)}
-                        style={{
-                            width: '250px',
-                            textAlign: 'left',
-                            padding: '10px 20px',
-                            fontSize: '16px',
-                            borderRadius: '8px',
-                            border: '1px solid #ccc',
-                            backgroundColor: '#f0f0f0',
-                            cursor: 'pointer',
-                            transition: 'background-color 0.3s',
-                        }}
+                        className="auth-request-button"
                         onMouseEnter={e => e.target.style.backgroundColor = '#e0e0e0'}
                         onMouseLeave={e => e.target.style.backgroundColor = '#f0f0f0'}
                     >

--- a/openid4vp-service/ovp-client/src/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/QrScreen.js
@@ -14,6 +14,7 @@ const QrScreen = () => {
     const [scanResult, setScanResult] = useState(null);
     const [copied, setCopied] = useState(false);
     const [copiedResult, setCopiedResult] = useState(false);
+    const [copiedAuthRequest, setCopiedAuthRequest] = useState(false);
     const [showInputData, setShowInputData] = useState(false);
     const [actualAuthorizationRequestObject, setActualAuthorizationRequestObject] = useState(null);
 
@@ -70,31 +71,62 @@ const QrScreen = () => {
     const renderActualAuthRequestObject = () => {
         return <>
             {actualAuthorizationRequestObject && (
-                <div style={{flex: 1}}>
-                    <h2>Actual Authorization Request Object</h2>
-                    <div
-                        style={{
-                            background: '#f4f4f4',
-                            padding: '16px',
-                            borderRadius: '6px',
-                            fontSize: '14px',
-                            fontFamily: 'monospace',
-                            whiteSpace: 'pre-wrap',
-                            wordBreak: 'break-word',
-                            maxWidth: '100%',
-                            overflowX: 'auto'
-                        }}
-                    >
-                            <pre style={{margin: 0}}>
-                              {JSON.stringify(actualAuthorizationRequestObject, null, 2)}
-                            </pre>
+                <div style={{flex: 1, marginTop: '16px'}}>
+                    <div className="section-header" style={{
+                        display: 'flex', 
+                        justifyContent: 'space-between', 
+                        alignItems: 'center',
+                        marginBottom: '8px'
+                    }}>
+                        <h2 style={{margin: 0}}>Actual Authorization Request Object</h2>
+                        <div className="copy-button-container" style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+                            {copiedAuthRequest && (
+                                <div
+                                    style={{
+                                        padding: '6px 12px',
+                                        backgroundColor: '#4caf50',
+                                        color: 'white',
+                                        borderRadius: '4px',
+                                        fontSize: '12px',
+                                        boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+                                        zIndex: 1,
+                                        whiteSpace: 'nowrap'
+                                    }}
+                                >
+                                    Copied!
+                                </div>
+                            )}
+                            <button
+                                onClick={() =>
+                                    handleCopy(
+                                        JSON.stringify(actualAuthorizationRequestObject, null, 2),
+                                        setCopiedAuthRequest
+                                    )
+                                }
+                                style={{
+                                    padding: '6px 12px',
+                                    fontSize: '12px',
+                                    borderRadius: '4px',
+                                    border: '1px solid #ccc',
+                                    backgroundColor: '#eee',
+                                    cursor: 'pointer',
+                                }}
+                            >
+                                Copy
+                            </button>
+                        </div>
+                    </div>
+                    <div className="json-display-block">
+                        <pre style={{margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word'}}>
+                            {JSON.stringify(actualAuthorizationRequestObject, null, 2)}
+                        </pre>
                     </div>
                 </div>
             )}
         </>;
     }
     return (
-        <div style={{padding: '40px'}}>
+        <div className="responsive-container">
             <button
                 onClick={() => navigate('/')}
                 style={{
@@ -109,10 +141,10 @@ const QrScreen = () => {
             >
                 ← Back
             </button>
-            <h1 style={{marginBottom: '20px'}}>Scan screen</h1>
-            <div style={{display: 'flex'}}>
+            <h1 className="page-title">Scan screen</h1>
+            <div className="two-column-layout">
 
-                <div style={{flex: 1, marginRight: '40px', maxWidth: '50%'}}>
+                <div className="qr-code-section">
 
 
                     {qrCodeData && qrData ? (
@@ -121,13 +153,7 @@ const QrScreen = () => {
                                 <img
                                     src={qrCodeData}
                                     alt="QR Code"
-                                    style={{
-                                        width: '400px',
-                                        height: '400px',
-                                        marginBottom: '10px',
-                                        cursor: 'pointer',
-                                        display: 'block',
-                                    }}
+                                    className="qr-code-image"
                                 />
                             </a>
 
@@ -172,21 +198,8 @@ const QrScreen = () => {
                     </button>
 
                     {showInputData && (
-                        <div
-                            style={{
-                                background: '#f4f4f4',
-                                padding: '16px',
-                                borderRadius: '6px',
-                                fontSize: '14px',
-                                fontFamily: 'monospace',
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-word',
-                                marginTop: '10px',
-                                maxWidth: '600px',
-                                overflowX: 'auto'
-                            }}
-                        >
-                            <pre style={{margin: 0}}>
+                        <div className="json-display-block" style={{ marginTop: '10px' }}>
+                            <pre style={{ margin: 0 }}>
                               {JSON.stringify(inputData, null, 2)}
                             </pre>
                         </div>
@@ -195,63 +208,50 @@ const QrScreen = () => {
                     {renderActualAuthRequestObject()}
 
                     {qrData && (
-                        <div style={{position: 'relative', marginTop: '16px'}}>
-                            <h4 style={{marginBottom: '8px'}}>Payload</h4>
-
-                            {copied && (
-                                <div
-                                    style={{
-                                        position: 'absolute',
-                                        right: '80px',
-                                        top: '10px',
-                                        padding: '6px 12px',
-                                        backgroundColor: '#4caf50',
-                                        color: 'white',
-                                        borderRadius: '4px',
-                                        fontSize: '12px',
-                                        boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
-                                    }}
-                                >
-                                    Copied!
+                        <div style={{marginTop: '16px'}}>
+                            <div className="section-header" style={{
+                                display: 'flex', 
+                                justifyContent: 'space-between', 
+                                alignItems: 'center',
+                                marginBottom: '8px'
+                            }}>
+                                <h4 style={{margin: 0}}>Payload</h4>
+                                <div className="copy-button-container" style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+                                    {copied && (
+                                        <div
+                                            style={{
+                                                padding: '6px 12px',
+                                                backgroundColor: '#4caf50',
+                                                color: 'white',
+                                                borderRadius: '4px',
+                                                fontSize: '12px',
+                                                boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+                                            }}
+                                        >
+                                            Copied!
+                                        </div>
+                                    )}
+                                    <button
+                                        onClick={() =>
+                                            handleCopy(
+                                                typeof qrData === 'string' ? qrData : JSON.stringify(qrData, null, 2),
+                                                setCopied
+                                            )
+                                        }
+                                        style={{
+                                            padding: '6px 12px',
+                                            fontSize: '12px',
+                                            borderRadius: '4px',
+                                            border: '1px solid #ccc',
+                                            backgroundColor: '#eee',
+                                            cursor: 'pointer',
+                                        }}
+                                    >
+                                        Copy
+                                    </button>
                                 </div>
-                            )}
-
-                            <button
-                                onClick={() =>
-                                    handleCopy(
-                                        typeof qrData === 'string' ? qrData : JSON.stringify(qrData, null, 2),
-                                        setCopied
-                                    )
-                                }
-                                style={{
-                                    position: 'absolute',
-                                    right: '10px',
-                                    top: '10px',
-                                    padding: '4px 8px',
-                                    fontSize: '12px',
-                                    borderRadius: '4px',
-                                    border: '1px solid #ccc',
-                                    backgroundColor: '#eee',
-                                    cursor: 'pointer',
-                                }}
-                            >
-                                Copy
-                            </button>
-
-                            <div
-                                style={{
-                                    background: '#f4f4f4',
-                                    padding: '16px',
-                                    borderRadius: '6px',
-                                    fontSize: '14px',
-                                    fontFamily: 'monospace',
-                                    maxHeight: '400px',
-                                    overflow: 'auto',
-                                    maxWidth: '100%',
-                                    whiteSpace: 'pre-wrap',
-                                    wordBreak: 'break-word',
-                                }}
-                            >
+                            </div>
+                            <div className="json-display-block">
                                 <pre style={{margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word'}}>
                                     {typeof qrData === 'string' ? qrData : JSON.stringify(qrData, null, 2)}
                                 </pre>
@@ -261,43 +261,32 @@ const QrScreen = () => {
                 </div>
 
 
-                <div style={{flex: 1, marginLeft: '40px'}}>
-                    <h2>Scan Result</h2>
-                    {scanResult ? (
-                        <div style={{position: 'relative'}}>
-                            {copiedResult && (
-                                <div
-                                    style={{
-                                        position: 'absolute',
-                                        right: '80px',
-                                        top: '10px',
-                                        padding: '6px 12px',
-                                        backgroundColor: '#4caf50',
-                                        color: 'white',
-                                        borderRadius: '4px',
-                                        fontSize: '12px',
-                                        boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
-                                        zIndex: 1,
-                                    }}
-                                >
-                                    Copied!
-                                </div>
-                            )}
-
-                            <div
-                                style={{
-                                    position: 'relative',
-                                    background: scanResult?.error ? '#ffe6e6' : '#e9ffe9',
-                                    padding: '16px',
-                                    borderRadius: '6px',
-                                    fontSize: '14px',
-                                    fontFamily: 'monospace',
-                                    whiteSpace: 'pre-wrap',
-                                    wordBreak: 'break-word',
-                                    width: '100%',
-                                    overflow: 'hidden',
-                                }}
-                            >
+                <div className="scan-result-section" style={{marginTop: '-10px'}}>
+                    <div className="section-header" style={{
+                        display: 'flex', 
+                        justifyContent: 'space-between', 
+                        alignItems: 'center',
+                        marginBottom: '8px'
+                    }}>
+                        <h2 className="section-title" style={{margin: 0}}>Scan Result</h2>
+                        {scanResult && (
+                            <div className="copy-button-container" style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+                                {copiedResult && (
+                                    <div
+                                        style={{
+                                            padding: '6px 12px',
+                                            backgroundColor: '#4caf50',
+                                            color: 'white',
+                                            borderRadius: '4px',
+                                            fontSize: '12px',
+                                            boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+                                            zIndex: 1,
+                                            whiteSpace: 'nowrap'
+                                        }}
+                                    >
+                                        Copied!
+                                    </div>
+                                )}
                                 <button
                                     onClick={() =>
                                         handleCopy(
@@ -306,10 +295,7 @@ const QrScreen = () => {
                                         )
                                     }
                                     style={{
-                                        position: 'absolute',
-                                        top: '10px',
-                                        right: '10px',
-                                        padding: '4px 8px',
+                                        padding: '6px 12px',
                                         fontSize: '12px',
                                         borderRadius: '4px',
                                         border: '1px solid #ccc',
@@ -319,10 +305,27 @@ const QrScreen = () => {
                                 >
                                     Copy
                                 </button>
-                                <pre style={{margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word'}}>
-                                    {JSON.stringify(prettyScanResult(scanResult), null, 2)}
-                                </pre>
                             </div>
+                        )}
+                    </div>
+
+                    {scanResult ? (
+                        <div
+                            style={{
+                                background: scanResult?.error ? '#ffe6e6' : '#e9ffe9',
+                                padding: '16px',
+                                borderRadius: '6px',
+                                fontSize: '14px',
+                                fontFamily: 'monospace',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-word',
+                                width: '100%',
+                                boxSizing: 'border-box'
+                            }}
+                        >
+                            <pre style={{ margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                                {JSON.stringify(prettyScanResult(scanResult), null, 2)}
+                            </pre>
                         </div>
                     ) : (
                         <div
@@ -332,6 +335,9 @@ const QrScreen = () => {
                                 borderRadius: '6px',
                                 fontSize: '14px',
                                 fontFamily: 'monospace',
+                                textAlign: 'center',
+                                width: '100%',
+                                boxSizing: 'border-box'
                             }}
                         >
                             Waiting for scan result...

--- a/openid4vp-service/ovp-client/src/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/QrScreen.js
@@ -30,6 +30,9 @@ const QrScreen = () => {
                 if (state.endpoint === "/verifier/generate-auth-request-by-reference-qr") {
                     const response = await axios.get(`${BACKEND_URL}/verifier/get-auth-request-obj`);
                     setActualAuthorizationRequestObject(response.data);
+                } else if (state.endpoint === "/verifier/generate-auth-request-by-reference-qr-draft21") {
+                    const response = await axios.get(`${BACKEND_URL}/verifier/get-auth-request-obj-draft21`);
+                    setActualAuthorizationRequestObject(response.data);
                 }
             } catch (err) {
                 console.error('Failed to fetch QR code:', err);

--- a/openid4vp-service/ovp-client/src/index.css
+++ b/openid4vp-service/ovp-client/src/index.css
@@ -11,3 +11,213 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* Defined responsive ui classes */
+.responsive-container {
+  padding: 20px;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .responsive-container {
+    padding: 40px;
+  }
+}
+
+.two-column-layout {
+  display: flex;
+  flex-direction: row;
+  gap: 15px;
+  width: 100%;
+  align-items: flex-start;
+}
+
+.qr-code-section {
+  flex: 0 0 45%;
+  max-width: 45%;
+  min-width: 200px;
+  align-self: flex-start;
+  margin-right: 10px;
+}
+
+.scan-result-section {
+  flex: 1;
+  max-width: 55%;
+  min-width: 0;
+  align-self: flex-start;
+  margin-left: 10px;
+}
+
+.qr-code-image {
+  width: 100%;
+  max-width: 400px;
+  height: auto;
+  margin-bottom: 10px;
+  cursor: pointer;
+  display: block;
+}
+
+.json-display-block {
+  background: #f4f4f4;
+  padding: 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 100%;
+  box-sizing: border-box;
+  line-height: 1.4;
+}
+
+@media (min-width: 768px) {
+  .json-display-block {
+    font-size: 14px;
+  }
+}
+
+.page-title {
+  font-size: clamp(1.8rem, 5vw, 2rem);
+  margin-bottom: 20px;
+  font-weight: 600;
+}
+
+.section-title {
+  font-size: clamp(1.4rem, 4vw, 1.5rem);
+  font-weight: 500;
+}
+
+.homepage-container {
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .homepage-container {
+    padding-left: 40px;
+    padding-top: 20px;
+  }
+}
+
+.auth-button-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 10px;
+  width: 100%;
+}
+
+.auth-request-button {
+  width: 100%;
+  max-width: 250px;
+  text-align: left;
+  padding: 10px 20px;
+  font-size: 16px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+  background-color: #f0f0f0;
+  cursor: pointer;
+  transition: background-color 0.3s;
+  box-sizing: border-box;
+  font-weight: 500;
+}
+
+.auth-request-button:hover {
+  background-color: #e0e0e0;
+}
+
+@media (max-width: 767px) {
+  .auth-request-button {
+    font-size: 16px;
+    padding: 10px 16px;
+    max-width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .responsive-container {
+    padding: 15px;
+  }
+  
+  .two-column-layout {
+    gap: 10px;
+  }
+  
+  .qr-code-section {
+    flex: 0 0 40%;
+    max-width: 40%;
+    min-width: 150px;
+    margin-right: 5px;
+  }
+  
+  .scan-result-section {
+    flex: 1;
+    max-width: 60%;
+    margin-left: 5px;
+  }
+  
+  .qr-code-image {
+    max-width: 180px;
+  }
+  
+  .json-display-block {
+    font-size: 11px;
+    padding: 10px;
+    position: relative;
+    line-height: 1.3;
+  }
+  
+  .page-title {
+    font-size: 1.6rem;
+    font-weight: 600 !important;
+  }
+  
+  .section-title {
+    font-size: 1.2rem;
+    font-weight: 500 !important;
+  }
+  
+  .qr-code-section h2, .qr-code-section h4 {
+    font-size: 14px;
+    margin: 5px 0;
+    font-weight: bold !important;
+  }
+  
+  .qr-code-section button {
+    font-size: 10px !important;
+    padding: 4px 8px !important;
+  }
+  
+  .scan-result-section button {
+    font-size: 10px !important;
+    padding: 4px 8px !important;
+  }
+  
+  .scan-result-section {
+    margin-top: -15px !important;
+  }
+}
+
+/* Section header styling to make text sizes consistent */
+.section-header h2 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-header h4 {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* Mobile adjustments for section headers */
+@media (max-width: 480px) {
+  .section-header h2,
+  .section-header h4 {
+    font-size: 12px !important;
+    font-weight: 600 !important;
+    margin: 0 !important;
+  }
+}


### PR DESCRIPTION
## Summary
Added Draft 21 QR code generation alongside existing Draft 23 functionality in OpenID4VP mock UI.

## Changes
- Added Draft 21 endpoints with `client_id_scheme` parameter support
- Created two-step UI: select request type → select draft version

## UI Flow Screenshots
<img width="250" alt="Step 1: Select Request Type" src="https://github.com/user-attachments/assets/0109afaf-d68e-43e1-bd8e-50d73818fa13" /> <img width="250" alt="Step 2: Select Draft Version" src="https://github.com/user-attachments/assets/6a2e4d32-2733-4678-b719-c2692c623a01" /> <img width="200" alt="Step 3: QR Code Generated" src="https://github.com/user-attachments/assets/492d9f3b-3631-4919-8c41-eb9cd7d66ebd" />