### PR TITLE
[INJIMOB-3455] refactor: add ngrok skip warning header for api calls

### DIFF
--- a/openid4vp-service/ovp-client/src/components/scan/ScanResult.js
+++ b/openid4vp-service/ovp-client/src/components/scan/ScanResult.js
@@ -16,7 +16,11 @@ export function ScanResult() {
     useEffect(() => {
         const interval = setInterval(async () => {
             try {
-                const response = await axios.get(`${BACKEND_URL}/verifier/vp-result`);
+                const response = await axios.get(`${BACKEND_URL}/verifier/vp-result`, {
+                    headers: {
+                        'ngrok-skip-browser-warning': 'true'
+                    }
+                });
                 if (response.data && response.data !== false) {
                     setScanResult(response.data);
                 }

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -79,7 +79,11 @@ const QrScreen = () => {
     const fetchQrCodeData = async (clientIdScheme: string, requestMode: string, draftVersion: string = DRAFT_VERSIONS.DRAFT_23) => {
         try {
             // /verifier/<client_id_scheme>/<request_mode>-qr?draft=<draft_version>
-            const response = await axios.get(`${BACKEND_URL}/verifier/${clientIdScheme}/${requestMode}?draft=${draftVersion}`);
+            const response = await axios.get(`${BACKEND_URL}/verifier/${clientIdScheme}/${requestMode}?draft=${draftVersion}`, {
+                headers: {
+                    'ngrok-skip-browser-warning': 'true'
+                }
+            });
 
             if (response.status !== 200) {
                 setErrorMessage("Error fetching QR code data");


### PR DESCRIPTION
At times ngrok warnings are affecting the API calls if the backend ovp mock service is exposed via ngrok. So a header param is added to avoid such scenarios