### PR TITLE
Injiweb 1747 - OpenID4VP Flow : Verifier request URL format change

### DIFF
--- a/openid4vp-service/ovp-client/src/constants/mockui-constants.js
+++ b/openid4vp-service/ovp-client/src/constants/mockui-constants.js
@@ -1,3 +1,3 @@
 export const BACKEND_URL = "http://localhost:3000"; // add your local backend url / tunnel here
-export const INJIWEB_URL = "http://localhost:3004/user/authorize"; // InjiWeb URL for authorization
+export const INJIWEB_URL = "http://localhost:3004/authorize"; // InjiWeb URL for authorization
 

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -158,17 +158,7 @@ const QrScreen = () => {
     }
 
     const handleOpenInjiWeb = () => {
-        let encodedRequest = '';
-
-        if (actualAuthorizationRequestObject) {
-            // For "By Reference" mode, use the fetched authorization request object
-            encodedRequest = actualAuthorizationRequestObject;
-        } else if (qrData) {
-            // For "By Value" mode, use the qrData (URL string) as the authorization request
-            encodedRequest = qrData;
-        }
-
-        const strippedRequest = encodedRequest.split('?')[1] || '';
+        const strippedRequest = qrData.split('?')[1] || '';
         window.open(`${INJIWEB_URL}?${strippedRequest}`, '_blank');
     }
 

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -168,7 +168,7 @@ const QrScreen = () => {
             encodedRequest = qrData;
         }
 
-        const strippedRequest = encodedRequest.replace(/^.*?(?=client_id=)/, '');
+        const strippedRequest = encodedRequest.split('?')[1] || '';
         window.open(`${INJIWEB_URL}?${strippedRequest}`, '_blank');
     }
 

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -168,7 +168,8 @@ const QrScreen = () => {
             encodedRequest = qrData;
         }
 
-        window.open(`${INJIWEB_URL}?authorizationRequestUrl=${encodedRequest}`, '_blank');
+        const strippedRequest = encodedRequest.replace(/^.*?(?=client_id=)/, '');
+        window.open(`${INJIWEB_URL}?${strippedRequest}`, '_blank');
     }
 
     const header = () => {


### PR DESCRIPTION
Modified the InjiWeb url from /user/authorize to /authorize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the authorization endpoint URL used by the client to match the expected routing.
  * Updated how authorization request parameters are constructed and sent from QR-based flows so the raw query string from the QR is forwarded consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->