### PR TITLE
fix: general cleanup and small fixes after integration testing.

### DIFF
--- a/mock-issuer-service/src/as/metadata.js
+++ b/mock-issuer-service/src/as/metadata.js
@@ -26,7 +26,7 @@ export default function authServerMetadata(req, res) {
 
     interactive_authorization_endpoint: `${AS_ISSUER}/interactive-authorization`,
     // Nice to have: helps debuggers & wallet UIs
-    scopes_supported: ["degree.read", "openid"],
+    scopes_supported: ["degree.read", "jwt_vc_json.read", "openid"],
     token_endpoint_auth_methods_supported: ["none"],
 
     // For OpenID4VCI, authorization_details will be used

--- a/mock-issuer-service/src/credential/endpoint.js
+++ b/mock-issuer-service/src/credential/endpoint.js
@@ -3,7 +3,7 @@ import { SignJWT, generateKeyPair, exportJWK } from 'jose';
 import { randomUUID } from 'node:crypto'; // Added for dynamic JTI
 // import { accessTokenStore } from "../as/authz-store.js";
 
-const SUPPORTED_FORMATS = ["ldp_vc", "jwt_vc", "jwt_vc_json"];
+const SUPPORTED_FORMATS = ["ldp_vc", "jwt_vc_json"];
 
 export default async function credentialEndpoint(req, res) {
   const { format, proof } = req.body;
@@ -23,7 +23,6 @@ export default async function credentialEndpoint(req, res) {
   }
 
   // ---- Validate proof (mock) ----
-  // MOVED UP: Check proof BEFORE returning JWT to satisfy CodeRabbit
   if (!proof || !proof.jwt) {
     return res.status(400).json({
       error: "invalid_proof",
@@ -31,26 +30,21 @@ export default async function credentialEndpoint(req, res) {
     });
   }
 
-  // ---- JWT VC Logic (Added for INJIMOB-3752) ----
-  if (format === "jwt_vc" || format === "jwt_vc_json") {
+  // ---- JWT VC Logic ----
+  if (format === "jwt_vc_json") {
     try {
-      // 1. Generate a real Key Pair (ES256) on the fly
       const { privateKey, publicKey } = await generateKeyPair('ES256');
       
-      // 2. Create the DID:JWK from the public key
       const publicJwk = await exportJWK(publicKey);
       const didJwk = `did:jwk:${Buffer.from(JSON.stringify(publicJwk)).toString('base64url')}`;
       
-      // 3. Prepare the Payload 
-      // Remove static timestamps so we don't leak stale 'nbf' or 'iat' values
       const { iat, nbf, exp, ...cleanStaticVc } = STATIC_JWT_VC;
 
       const vcPayload = { 
         ...cleanStaticVc, 
         iss: didJwk,  
         sub: didJwk,
-        jti: `urn:uuid:${randomUUID()}`, // Dynamic JTI to prevent replay issues
-        // Fix: Ensure credentialSubject.id matches the subject (sub) per W3C spec
+        jti: `urn:uuid:${randomUUID()}`,
         vc: {
           ...STATIC_JWT_VC.vc,
           credentialSubject: {
@@ -60,17 +54,15 @@ export default async function credentialEndpoint(req, res) {
         }
       };
 
-      // 4. Sign it (Using Cryptography!)
       const jwt = await new SignJWT(vcPayload)
         .setProtectedHeader({ alg: 'ES256', typ: 'JWT', kid: didJwk })
         .setIssuedAt()
-        .setNotBefore('0s') // FIX: Set fresh 'nbf' (valid from now)
+        .setNotBefore('0s')
         .setExpirationTime('1y')
         .sign(privateKey);
 
-      // 5. Return the Valid JWT
       return res.json({
-        format: format, // Echo the requested format (jwt_vc or jwt_vc_json)
+        format: format,
         credential: jwt, 
         c_nonce: "mock_nonce_123",
         c_nonce_expires_in: 86400
@@ -86,7 +78,7 @@ export default async function credentialEndpoint(req, res) {
   return res.json({
     format: "ldp_vc",
     credential: STATIC_LDP_VC,
-    c_nonce: "mock_nonce_123", // Added consistency for LDP path to satify Coderabbit
+    c_nonce: "mock_nonce_123",
     c_nonce_expires_in: 86400
   });
 }

--- a/mock-issuer-service/src/credential/offer.js
+++ b/mock-issuer-service/src/credential/offer.js
@@ -10,7 +10,7 @@ export default function credentialOfferHandler(req, res) {
   // The credential_configuration_id that your mock issuer supports
   const credentialConfigurations = [
     "UniversityDegreeCredential",
-    //"JwtVerifiableCredential"
+    "JwtVerifiableCredential"
   ];
 
   const response = {

--- a/mock-issuer-service/src/credential/offer.js
+++ b/mock-issuer-service/src/credential/offer.js
@@ -10,6 +10,7 @@ export default function credentialOfferHandler(req, res) {
   // The credential_configuration_id that your mock issuer supports
   const credentialConfigurations = [
     "UniversityDegreeCredential",
+    //"JwtVerifiableCredential"
   ];
 
   const response = {

--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -30,12 +30,12 @@ export default function issuerMetadata(req, res) {
       },
       "JwtVerifiableCredential": {
         format: "jwt_vc_json",
-        scope: "jwt_vc.read",
+        scope: "jwt_vc_json.read",
         cryptographic_binding_methods_supported: ["did:jwk"],
         credential_signing_alg_values_supported: ["ES256"],
         proof_types_supported: {
           jwt: {
-            proof_signing_alg_values_supported: ["ES256"]
+            proof_signing_alg_values_supported: ["ES256", "RS256"]
           }
         },
         credential_definition: {


### PR DESCRIPTION
Key Changes:

Format Standardization: Removed the redundant jwt_vc format, standardizing all logic and endpoints on jwt_vc_json.

Metadata Alignment: Updated scopes_supported and credential configuration scopes from jwt_vc.read to jwt_vc_json.read.

Expanded proof_signing_alg_values_supported to include RS256 along with our existing ES256 to so the wallet wouldn't reject it as mentioned during the integration testing.

Logic Cleanup: Refactored credentialEndpoint to remove legacy conditional checks for jwt_vc. Updated the credentialOfferHandler to correctly reference JwtVerifiableCredential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JwtVerifiableCredential as a supported credential configuration.
  * Added RS256 signature algorithm support for JWT credentials.

* **Updates**
  * Updated JWT credential scope naming for consistency.
  * Removed legacy jwt_vc format; now exclusively supports jwt_vc_json format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->