### PR TITLE
feat: add multi-language display metadata for JWT VC

### DIFF
--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -31,6 +31,32 @@ export default function issuerMetadata(req, res) {
       "JwtVerifiableCredential": {
         format: "jwt_vc_json",
         scope: "jwt_vc_json.read",
+        "display": [
+          {
+            name: "Employee Credential",
+            locale: "en"
+          },
+          {
+            name: "Kard ng Pagkakakilanlan",
+            locale: "fil"
+          },
+          {
+            name: "पहचान पत्र",
+            locale: "hi"
+          },
+          {
+            name: "ಗುರುತಿನ ಚೀಟಿ",
+            locale: "kn"
+          },
+          {
+            name: "அடையாள அட்டை",
+            locale: "ta"
+          },
+          {
+            name: "بطاقة الهوية",
+            locale: "ar"
+          }
+      ],
         cryptographic_binding_methods_supported: ["did:jwk"],
         credential_signing_alg_values_supported: ["ES256"],
         proof_types_supported: {

--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -37,23 +37,23 @@ export default function issuerMetadata(req, res) {
             locale: "en"
           },
           {
-            name: "Kard ng Pagkakakilanlan",
+            name: "Kredensyal ng Empleyado",
             locale: "fil"
           },
           {
-            name: "पहचान पत्र",
+            name: "कर्मचारी क्रेडेंशियल",
             locale: "hi"
           },
           {
-            name: "ಗುರುತಿನ ಚೀಟಿ",
+            name: "ಉದ್ಯೋಗಿ ರುಜುವಾತು",
             locale: "kn"
           },
           {
-            name: "அடையாள அட்டை",
+            name: "பணியாளர் நற்சான்றிதழ்",
             locale: "ta"
           },
           {
-            name: "بطاقة الهوية",
+            name: "اعتماد الموظف",
             locale: "ar"
           }
       ],


### PR DESCRIPTION
Description
This PR updates the mock issuer metadata to support localized display names for JWT Verifiable Credentials (jwt_vc_json). By providing a localized display array, the Inji wallet can now dynamically render the credential name in the user's system language, ensuring a consistent user experience across all supported locales.

Changes
Updated JwtVerifiableCredential configuration in the mock service.

Added a display array containing localized objects with specific name and locale pairs.

Terminology has been strictly aligned with the existing wallet localization files:

English (en): "Employee Credential"

Filipino (fil): "Kredensyal ng Empleyado"

Hindi (hi): "कर्मचारी क्रेडेंशियल"

Kannada (kn): "ಉದ್ಯೋಗಿ ರುಜುವಾತು"

Tamil (ta): "பணியாளர் நற்சான்றிதழ்"

Arabic (ar): "اعتماد الموظف"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Credentials now support multilingual display names with full localization in English, Filipino, Hindi, Kannada, Tamil, and Arabic languages. Users will see credential information presented in their preferred language, significantly enhancing accessibility and improving the overall user experience for international communities using the platform globally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->