### PR TITLE
feat(issuer): add OID4VCI v1 credential flows

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,0 +1,14 @@
+fileignoreconfig:
+- filename: mock-issuer-service/package-lock.json
+  checksum: 45d17ca4d0e805b22542189d5024afb82680fdef3f6c8c974b6af66c5499298a
+- filename: mock-issuer-service/src/credential/sd-jwt.js
+  checksum: ecac23dc28784ec7be51f46c486553b30112ac27ea37b34652cb507587b4b596
+- filename: mock-issuer-service/package.json
+  checksum: 3bcb89b8a55ea83a200adfe55424e3e7bf633db2a9b5bde5191bf480ccacc14e
+- filename: mock-issuer-service/src/credential/ldp-vc.js
+  checksum: 6459b9607ece31c1e9c25c690e5fae494a7e0768e02490dd6de62faba33fb033
+- filename: mock-issuer-service/src/credential/mdoc.js
+  checksum: f4ea62802e3241c048bffcfc24d9e8b54b148a171d654c7c0abab32aaaa303d2
+- filename: mock-issuer-service/src/credential/endpoint.js
+  checksum: a84335bbc04c8b6cc8981e0d335147d01ef7f5f3fcfc0d56c9312972c29d80d5
+version: ""

--- a/mock-issuer-service/README.md
+++ b/mock-issuer-service/README.md
@@ -18,6 +18,7 @@ A lightweight **mock OpenID for Verifiable Credential Issuer** built with **Node
 * ✅ Credential Offer endpoint
 * ✅ Authorization + Token flow
 * ✅ Credential issuance endpoint
+* ✅ Support for multiple formats: **LDP-VC, JWT-VC, SD-JWT, and mdoc**
 * ✅ HTTPS support (required by wallets)
 * ✅ QR endpoint for easy testing
 

--- a/mock-issuer-service/package-lock.json
+++ b/mock-issuer-service/package-lock.json
@@ -8,15 +8,190 @@
       "name": "mock-issuer-service",
       "version": "1.0.0",
       "dependencies": {
+        "@digitalbazaar/ed25519-signature-2018": "^4.2.0",
+        "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
+        "cbor-x": "^1.6.4",
         "cors": "^2.8.5",
+        "cose-js": "^0.9.0",
         "dotenv": "^16.4.0",
         "express": "^4.19.0",
         "jose": "^5.2.0",
+        "jsonld": "^9.0.0",
+        "jsonld-signatures": "^11.6.0",
         "qrcode": "^1.5.4"
       },
       "devDependencies": {
         "nodemon": "^3.0.0"
       }
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
+      "integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
+      "integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
+      "integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
+      "integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
+      "integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
+      "integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@digitalbazaar/ed25519-signature-2018": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ed25519-signature-2018/-/ed25519-signature-2018-4.2.0.tgz",
+      "integrity": "sha512-JZn8oazkjKMU4+yg+7ogk3yXWyUVJ4XyWi7CQrTrJEHuBd+YbztaeZQBMFX3Ic1iDag3yoH+CgotrbCrtf3HJQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
+        "@digitalbazaar/ed25519-verification-key-2020": "^4.2.0",
+        "@digitalbazaar/jws-linked-data-signature": "^3.0.0",
+        "base58-universal": "^2.0.0",
+        "ed25519-signature-2018-context": "^1.1.0",
+        "ed25519-signature-2020-context": "^1.1.0",
+        "jsonld": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/ed25519-verification-key-2018": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ed25519-verification-key-2018/-/ed25519-verification-key-2018-4.0.0.tgz",
+      "integrity": "sha512-65O08XDDJYZVeQJ86fd7ClZLzMwQsJ0zQpLhvzjE9LRGrD0BPwWFrC/vNW3XTYzzvNwbP7ipFomF95JgGLzabQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/ed25519": "^1.6.0",
+        "base58-universal": "^2.0.0",
+        "crypto-ld": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@digitalbazaar/ed25519-verification-key-2020": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/ed25519-verification-key-2020/-/ed25519-verification-key-2020-4.2.0.tgz",
+      "integrity": "sha512-urEVTYkt+uYD8GjdoS6gkm2sKBich1hqx42b6vvUOmNgF0agZ95JlUjiJXEx+VOwu7WSjJSnEBph2Qatkrk1CA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/ed25519": "^1.6.0",
+        "base58-universal": "^2.0.0",
+        "base64url-universal": "^2.0.0",
+        "crypto-ld": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
+      "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ky": "^1.14.2",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@digitalbazaar/jws-linked-data-signature": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/jws-linked-data-signature/-/jws-linked-data-signature-3.0.0.tgz",
+      "integrity": "sha512-OE0LIwXeF3P8GZKphXb7jLqgUFMnDtbKZQCOqfMysUUIg2f4CLZIEbYbzZEP3cAE/MLoubIxl81QeGRyZ71ICg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "base64url-universal": "^2.0.0",
+        "jsonld-signatures": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@digitalbazaar/security-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/security-context/-/security-context-1.0.1.tgz",
+      "integrity": "sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.5.tgz",
+      "integrity": "sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -30,6 +205,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/aes-cbc-mac": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/aes-cbc-mac/-/aes-cbc-mac-1.0.1.tgz",
+      "integrity": "sha512-F1U0qNBNyrW82LRdQvYWKOpljZFnJ9LBUGWNCzCBTC3/+Fki77KgDrfJ+rBVlCpcmMT3jDEGhG61RMVeyHAKog==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -55,6 +236,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -75,12 +262,51 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base58-universal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base58-universal/-/base58-universal-2.0.0.tgz",
+      "integrity": "sha512-BgkgF8zVLOAygszG4W8NkLm7iXrw80VYAOcedrzANrIhS14+4W6zVqjyGTFUBM/FpqkHUt8aAYd4DbBBfn3zKg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/base64url-universal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64url-universal/-/base64url-universal-2.0.0.tgz",
+      "integrity": "sha512-6Hpg7EBf3t148C3+fMzjf+CHnADVDafWzlJUXAqqqbm4MKNXbsoPdOkWeRTjNlkYG7TpyjIpRO1Gk0SnsFD1rw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "base64url": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -94,6 +320,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -158,6 +390,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -203,6 +441,58 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-8.1.0.tgz",
+      "integrity": "sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/cbor-extract": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.2.tgz",
+      "integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.4.tgz",
+      "integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.2"
       }
     },
     "node_modules/chokidar": {
@@ -315,6 +605,32 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cose-js": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cose-js/-/cose-js-0.9.0.tgz",
+      "integrity": "sha512-iYQvus+3LmjqXE2VkNKPQMZ5x+frSrk7WfSB7asTHYqpBuAG1ezdUEqJ5lXDuGoLbOSDOFAIgslawjkI2fX/hQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aes-cbc-mac": "^1.0.1",
+        "any-promise": "^1.3.0",
+        "cbor": "^8.1.0",
+        "elliptic": "^6.4.0",
+        "node-hkdf-sync": "^1.0.0",
+        "node-rsa": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/crypto-ld": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-ld/-/crypto-ld-7.0.0.tgz",
+      "integrity": "sha512-RrXy6aB0TOhSiqsgavTQt1G8mKomKIaNLb2JZxj7A/Vi0EwmXguuBQoeiAvePfK6bDR3uQbqYnaLLs4irTWwgw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -361,6 +677,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
@@ -393,11 +719,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ed25519-signature-2018-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ed25519-signature-2018-context/-/ed25519-signature-2018-context-1.1.0.tgz",
+      "integrity": "sha512-ppDWYMNwwp9bploq0fS4l048vHIq41nWsAbPq6H4mNVx9G/GxW3fwg4Ln0mqctP13MoEpREK7Biz8TbVVdYXqA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ed25519-signature-2020-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ed25519-signature-2020-context/-/ed25519-signature-2020-context-1.1.0.tgz",
+      "integrity": "sha512-dBGSmoUIK6h2vadDctrDnhhTO01PR2hJk0mRNEfrRDPCjaIwrfy4J+eziEQ9Q1m8By4f/CSRgKM1h53ydKfdNg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -519,6 +872,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
+      }
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -714,6 +1075,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -724,6 +1095,17 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/http-errors": {
@@ -840,6 +1222,48 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsonld-signatures": {
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz",
+      "integrity": "sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/security-context": "^1.0.0",
+        "jsonld": "^9.0.0",
+        "rdf-canonize": "^5.0.0",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -850,6 +1274,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/math-intrinsics": {
@@ -921,6 +1357,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -947,6 +1395,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-hkdf-sync": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-hkdf-sync/-/node-hkdf-sync-1.0.0.tgz",
+      "integrity": "sha512-dKe4X44YGLxPITIMdbnVw0URGTLw2lUUKmClar5iz53ZRrl3xGKk3k7KsBASRMHGh6bJCE1Gmuirb/QaL7rJuw==",
+      "dependencies": {
+        "vows": "0.5.13"
+      },
+      "engines": {
+        "node": ">= 0.6.5"
+      }
+    },
+    "node_modules/node-rsa": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+      "integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "^0.2.4"
       }
     },
     "node_modules/nodemon": {
@@ -976,6 +1459,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
       }
     },
     "node_modules/normalize-path": {
@@ -1179,6 +1671,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1294,6 +1798,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -1314,6 +1833,12 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1486,6 +2011,18 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -1505,6 +2042,15 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1533,6 +2079,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vows": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.5.13.tgz",
+      "integrity": "sha512-m2+3s/ITbI95b7uzsBnA7oZg7/bJZFb+sKp2TUvomrIQxjtuNOivf/yOxAAyhEAX8gkIogoXfBJRmj9ys8r3gQ==",
+      "dependencies": {
+        "eyes": ">=0.1.6"
+      },
+      "bin": {
+        "vows": "bin/vows"
+      },
+      "engines": {
+        "node": ">=0.2.6"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
@@ -1557,6 +2117,12 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
       "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/yargs": {

--- a/mock-issuer-service/package.json
+++ b/mock-issuer-service/package.json
@@ -7,10 +7,16 @@
     "start": "node src/server.js"
   },
   "dependencies": {
+    "@digitalbazaar/ed25519-signature-2018": "^4.2.0",
+    "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
+    "cbor-x": "^1.6.4",
     "cors": "^2.8.5",
+    "cose-js": "^0.9.0",
     "dotenv": "^16.4.0",
     "express": "^4.19.0",
     "jose": "^5.2.0",
+    "jsonld": "^9.0.0",
+    "jsonld-signatures": "^11.6.0",
     "qrcode": "^1.5.4"
   },
   "devDependencies": {

--- a/mock-issuer-service/src/as/authorize.js
+++ b/mock-issuer-service/src/as/authorize.js
@@ -1,8 +1,14 @@
 import fs from "fs";
 import path from "path";
+import { hasExplicitVersion, resolveRequestVersion } from "../issuer-profile.js";
 
 export default function authorizeHandler(req, res) {
   const { client_id, redirect_uri, state } = req.query;
+  const version = resolveRequestVersion(req);
+  const flowSegment = req.params?.flow === "pdi" ? "/pdi" : "";
+  const loginAction = hasExplicitVersion(req)
+    ? `/${version}${flowSegment}/as/login`
+    : `${flowSegment}/as/login`;
   console.log("Looking for HTML at:", path.resolve("src/as/login-page.html"));
 
   if (!client_id || !redirect_uri) {
@@ -22,6 +28,7 @@ export default function authorizeHandler(req, res) {
   const html = template
     .replace("{{client_id}}", client_id)
     .replace("{{redirect_uri}}", redirect_uri)
+    .replace("{{form_action}}", loginAction)
     .replace("{{state}}", state || "");
 
   res.set("Content-Type", "text/html");

--- a/mock-issuer-service/src/as/authz-store.js
+++ b/mock-issuer-service/src/as/authz-store.js
@@ -2,6 +2,7 @@ import crypto from "crypto";
 
 export const authCodeStore = new Map();
 export const accessTokenStore = new Map();
+export const preAuthCodeStore = new Map();
 
 export function generateAuthCode() {
   return crypto.randomBytes(16).toString("hex");

--- a/mock-issuer-service/src/as/interactive-authorization.js
+++ b/mock-issuer-service/src/as/interactive-authorization.js
@@ -1,7 +1,7 @@
 import crypto from "crypto";
 import { iarSessions } from "./iar-store.js";
 import { authCodeStore } from "./authz-store.js";
-import { ISSUER } from "../issuer-metadata.js";
+import { authServerBaseUrl, issuerBaseUrl, resolveRequestVersion } from "../issuer-profile.js";
 function randomSession() {
   return crypto.randomBytes(10).toString("hex");
 }
@@ -11,6 +11,11 @@ function randomCode() {
 }
 
 export default function interactiveAuthorizationHandler(req, res) {
+  const version = resolveRequestVersion(req);
+  const flow = req.params?.flow === "pdi" ? "pdi" : null;
+  const issuer = issuerBaseUrl(version, Boolean(req.params?.version), flow);
+  const authServer = authServerBaseUrl(version, Boolean(req.params?.version), flow);
+
   // --------------------------
   // CASE 1: PHASE 2 (wallet returns VP)
   // --------------------------
@@ -51,7 +56,7 @@ export default function interactiveAuthorizationHandler(req, res) {
       status: "authorization_code_issued",
       code: code,
       state: session.state || null,
-      iss: `${ISSUER}/as`,
+      iss: authServer,
     });
   }
 
@@ -157,6 +162,7 @@ export default function interactiveAuthorizationHandler(req, res) {
     status: "require_interaction",
     type: "openid4vp_presentation",
     auth_session: sessionId,
+    credential_issuer: issuer,
     openid4vp_request: requestObject,
   });
 }

--- a/mock-issuer-service/src/as/login-page.html
+++ b/mock-issuer-service/src/as/login-page.html
@@ -27,7 +27,7 @@
       <p><strong>User:</strong> demo user</p>
       <p><strong>Password:</strong> any password (mock)</p>
 
-      <form method="POST" action="/as/login">
+      <form method="POST" action="{{form_action}}">
         <input type="hidden" name="client_id" value="{{client_id}}" />
         <input type="hidden" name="redirect_uri" value="{{redirect_uri}}" />
         <input type="hidden" name="state" value="{{state}}" />

--- a/mock-issuer-service/src/as/metadata.js
+++ b/mock-issuer-service/src/as/metadata.js
@@ -1,18 +1,19 @@
-import { ISSUER } from "../issuer-metadata.js";
-
-// src/as/metadata.js
-const AS_ISSUER = `${ISSUER}/as`;
+import { authServerBaseUrl, hasExplicitVersion, resolveRequestVersion } from "../issuer-profile.js";
 
 export default function authServerMetadata(req, res) {
-  res.json({
+  const version = resolveRequestVersion(req);
+  const flow = req.params?.flow === "pdi" ? "pdi" : null;
+  const asIssuer = authServerBaseUrl(version, hasExplicitVersion(req), flow);
+
+  const response = {
     // The "issuer" of this Authorization Server
-    issuer: AS_ISSUER,
+    issuer: asIssuer,
 
     // Where the wallet will send the user for interactive authorization
-    authorization_endpoint: `${AS_ISSUER}/authorize`,
+    authorization_endpoint: `${asIssuer}/authorize`,
 
     // Where the wallet will later exchange the code for tokens
-    token_endpoint: `${AS_ISSUER}/token`,
+    token_endpoint: `${asIssuer}/token`,
 
     // Optional PAR (you can wire this later if you want)
     // pushed_authorization_request_endpoint: `${AS_ISSUER}/par`,
@@ -24,12 +25,17 @@ export default function authServerMetadata(req, res) {
     // We want wallets to use PKCE S256
     code_challenge_methods_supported: ["S256"],
 
-    interactive_authorization_endpoint: `${AS_ISSUER}/interactive-authorization`,
     // Nice to have: helps debuggers & wallet UIs
     scopes_supported: ["degree.read", "jwt_vc_json.read", "openid"],
     token_endpoint_auth_methods_supported: ["none"],
 
     // For OpenID4VCI, authorization_details will be used
     authorization_details_types_supported: ["openid_credential"]
-  });
+  };
+
+  if (flow === "pdi") {
+    response.interactive_authorization_endpoint = `${asIssuer}/interactive-authorization`;
+  }
+
+  res.json(response);
 }

--- a/mock-issuer-service/src/as/token.js
+++ b/mock-issuer-service/src/as/token.js
@@ -1,5 +1,5 @@
 import crypto from "crypto";
-import { authCodeStore } from "./authz-store.js";
+import { authCodeStore, preAuthCodeStore } from "./authz-store.js";
 
 function base64url(str) {
   return str.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
@@ -9,49 +9,86 @@ export default function tokenHandler(req, res) {
   const {
     grant_type,
     code,
+    "pre-authorized_code": preAuthorizedCode,
+    tx_code: txCodeInput,
     redirect_uri,
     client_id
   } = req.body;
-  console.log("Token Request:", grant_type, code);
-  // 1. Only authorization_code supported
-  if (grant_type !== "authorization_code") {
+  console.log("Token Request:", grant_type, code || preAuthorizedCode);
+
+  let scope;
+
+  if (grant_type === "authorization_code") {
+    // 2. Authorization code must exist
+    const entry = authCodeStore.get(code);
+    if (!entry) {
+      return res.status(400).json({
+        error: "invalid_grant",
+        error_description: "Invalid or expired authorization code"
+      });
+    }
+
+    // 3. Validate redirect_uri
+    if (redirect_uri !== entry.redirect_uri) {
+      return res.status(400).json({
+        error: "invalid_grant",
+        error_description: "redirect_uri mismatch"
+      });
+    }
+
+    // 4. Validate client_id
+    if (client_id !== entry.client_id) {
+      return res.status(400).json({
+        error: "invalid_client",
+        error_description: "client_id mismatch"
+      });
+    }
+    
+    scope = entry.scope;
+    authCodeStore.delete(code);
+  } else if (grant_type === "urn:ietf:params:oauth:grant-type:pre-authorized_code") {
+    if (!preAuthorizedCode) {
+      return res.status(400).json({
+        error: "invalid_request",
+        error_description: "pre-authorized_code missing"
+      });
+    }
+
+    const entry = preAuthCodeStore.get(preAuthorizedCode);
+    if (!entry) {
+      return res.status(400).json({
+        error: "invalid_grant",
+        error_description: "Invalid or expired pre-authorized code"
+      });
+    }
+
+    if (entry.txCode) {
+      if (txCodeInput === undefined || txCodeInput === null || txCodeInput === "") {
+        return res.status(400).json({
+          error: "invalid_request",
+          error_description: "tx_code is REQUIRED for this pre-authorized_code"
+        });
+      }
+      if (txCodeInput !== entry.txCode) {
+        return res.status(400).json({
+          error: "invalid_grant",
+          error_description: "Invalid tx_code"
+        });
+      }
+    }
+
+    scope = entry.scope;
+    preAuthCodeStore.delete(preAuthorizedCode);
+  } else {
     return res.status(400).json({
       error: "unsupported_grant_type",
-      error_description: "Only authorization_code grant is supported"
-    });
-  }
-
-  // 2. Authorization code must exist
-  const entry = authCodeStore.get(code);
-  if (!entry) {
-    return res.status(400).json({
-      error: "invalid_grant",
-      error_description: "Invalid or expired authorization code"
-    });
-  }
-
-  // 3. Validate redirect_uri
-  if (redirect_uri !== entry.redirect_uri) {
-    return res.status(400).json({
-      error: "invalid_grant",
-      error_description: "redirect_uri mismatch"
-    });
-  }
-
-  // 4. Validate client_id
-  if (client_id !== entry.client_id) {
-    return res.status(400).json({
-      error: "invalid_client",
-      error_description: "client_id mismatch"
+      error_description: "Only authorization_code and pre-authorized_code grants are supported"
     });
   }
 
   // 5. Issue access_token + c_nonce
   const accessToken = base64url(crypto.randomBytes(32).toString("base64"));
   const cNonce = base64url(crypto.randomBytes(16).toString("base64"));
-
-  // 6. Delete code after use
-  authCodeStore.delete(code);
 
   // 7. Return OAuth Token Response
   res.setHeader("Cache-Control", "no-store");
@@ -64,6 +101,6 @@ export default function tokenHandler(req, res) {
     c_nonce: cNonce,
     c_nonce_expires_in: 300,
 
-    scope: entry.scope
+    scope: scope
   });
 }

--- a/mock-issuer-service/src/credential/endpoint.js
+++ b/mock-issuer-service/src/credential/endpoint.js
@@ -1,84 +1,160 @@
-import { STATIC_LDP_VC, STATIC_JWT_VC } from "./static-vc.js";
+import {
+  STATIC_LDP_VC,
+  STATIC_JWT_VC,
+  STATIC_SD_JWT_VC,
+  STATIC_MDL_MDOC,
+  STATIC_MDL_MDOC_SAMPLE_B64URL,
+} from "./static-vc.js";
 import { SignJWT, generateKeyPair, exportJWK } from 'jose';
-import { randomUUID } from 'node:crypto'; // Added for dynamic JTI
-// import { accessTokenStore } from "../as/authz-store.js";
+import { randomUUID, createHash } from 'node:crypto';
+import { ISSUER } from "../issuer-metadata.js";
+import { hasExplicitVersion, issuerBaseUrl, resolveRequestVersion } from "../issuer-profile.js";
+import { createSdJwt } from "./sd-jwt.js";
+import { createMdoc } from "./mdoc.js";
+import { signLdpVc } from "./ldp-vc.js";
 
-const SUPPORTED_FORMATS = ["ldp_vc", "jwt_vc_json"];
+const SUPPORTED_FORMATS = ["ldp_vc", "jwt_vc_json", "vc+sd-jwt", "mso_mdoc"];
+
+// Minimal config-id → format map for the v1 flow where the client sends
+// credential_configuration_id instead of format.
+const CONFIG_TO_FORMAT = {
+  UniversityDegreeCredential: "ldp_vc",
+  JwtVerifiableCredential: "jwt_vc_json",
+  SdJwtVerifiableCredential: "vc+sd-jwt",
+  MdocVerifiableCredential: "mso_mdoc",
+};
 
 export default async function credentialEndpoint(req, res) {
-  const { format, proof } = req.body;
+  const body = req.body || {};
+  const explicitVersion = hasExplicitVersion(req);
+  const version = resolveRequestVersion(req);
+  const isV1 = explicitVersion
+    ? version === "v1"
+    : Boolean(body.credential_configuration_id || body.proofs);
+  const issuerUrl = explicitVersion ? issuerBaseUrl(version) : ISSUER;
 
-  
+  let format;
+  let proofJwt;
 
-//   const tokenData = accessTokenStore.get(access_token);
-//   if (!tokenData) {
-//     return res.status(401).json({ error: "invalid_token" });
-//   }
-
-  // ---- Validate format ----
-  if (!SUPPORTED_FORMATS.includes(format)) {
-    return res.status(400).json({
-      error: "unsupported_credential_format"
-    });
-  }
-
-  // ---- Validate proof (mock) ----
-  if (!proof || !proof.jwt) {
-    return res.status(400).json({
-      error: "invalid_proof",
-      error_description: "proof.jwt missing"
-    });
-  }
-
-  // ---- JWT VC Logic ----
-  if (format === "jwt_vc_json") {
-    try {
-      const { privateKey, publicKey } = await generateKeyPair('ES256');
-      
-      const publicJwk = await exportJWK(publicKey);
-      const didJwk = `did:jwk:${Buffer.from(JSON.stringify(publicJwk)).toString('base64url')}`;
-      
-      const { iat, nbf, exp, ...cleanStaticVc } = STATIC_JWT_VC;
-
-      const vcPayload = { 
-        ...cleanStaticVc, 
-        iss: didJwk,  
-        sub: didJwk,
-        jti: `urn:uuid:${randomUUID()}`,
-        vc: {
-          ...STATIC_JWT_VC.vc,
-          credentialSubject: {
-            ...STATIC_JWT_VC.vc.credentialSubject,
-            id: didJwk
-          }
-        }
-      };
-
-      const jwt = await new SignJWT(vcPayload)
-        .setProtectedHeader({ alg: 'ES256', typ: 'JWT', kid: didJwk })
-        .setIssuedAt()
-        .setNotBefore('0s')
-        .setExpirationTime('1y')
-        .sign(privateKey);
-
-      return res.json({
-        format: format,
-        credential: jwt, 
-        c_nonce: "mock_nonce_123",
-        c_nonce_expires_in: 86400
+  if (isV1) {
+    const configId = body.credential_configuration_id;
+    format = CONFIG_TO_FORMAT[configId];
+    if (!format) {
+      return res.status(400).json({
+        error: "unsupported_credential_type",
+        error_description: `Unknown credential_configuration_id: ${configId}`,
       });
-
-    } catch (error) {
-      console.error("Signing failed:", error);
-      return res.status(500).json({ error: "signing_error" });
     }
+
+    const jwtProofs = body.proofs && body.proofs.jwt;
+    const mdocProofs = body.proofs && body.proofs.mso_mdoc;
+    
+    if (format === "mso_mdoc") {
+        if (!mdocProofs || !Array.isArray(mdocProofs) || mdocProofs.length === 0) {
+          // Fallback to jwt if mdoc proofs missing but jwt present (some wallets might still use jwt proof for mdoc)
+          if (!jwtProofs || !Array.isArray(jwtProofs) || jwtProofs.length === 0) {
+            return res.status(400).json({
+                error: "invalid_proof",
+                error_description: "proofs.mso_mdoc missing or empty",
+            });
+          }
+          proofJwt = jwtProofs[0];
+        } else {
+            proofJwt = mdocProofs[0];
+        }
+    } else {
+        if (!jwtProofs || !Array.isArray(jwtProofs) || jwtProofs.length === 0) {
+            return res.status(400).json({
+                error: "invalid_proof",
+                error_description: "proofs.jwt missing or empty",
+            });
+        }
+        proofJwt = jwtProofs[0];
+    }
+  } else {
+    format = body.format;
+    if (!SUPPORTED_FORMATS.includes(format)) {
+      return res.status(400).json({ error: "unsupported_credential_format" });
+    }
+    if (!body.proof || !body.proof.jwt) {
+      return res.status(400).json({
+        error: "invalid_proof",
+        error_description: "proof.jwt missing",
+      });
+    }
+    proofJwt = body.proof.jwt;
   }
 
-  // ---- Return STATIC VC ----
+  let credential;
+
+  try {
+    if (format === "ldp_vc") {
+        let host;
+        try {
+            host = new URL(issuerUrl).host;
+        } catch (e) {
+            host = "mock-issuer.local";
+        }
+        const issuerDid = `did:web:${host}`;
+        
+        const { proof, ...unsignedVc } = STATIC_LDP_VC;
+        unsignedVc.issuer = issuerDid;
+        unsignedVc.issuanceDate = new Date().toISOString();
+
+        credential = await signLdpVc(unsignedVc, issuerDid);
+    } else {
+        const { privateKey, publicKey } = await generateKeyPair('ES256');
+        const privateKeyJwk = await exportJWK(privateKey);
+        const publicKeyJwk = await exportJWK(publicKey);
+        privateKeyJwk.kid = randomUUID();
+        publicKeyJwk.kid = privateKeyJwk.kid;
+        const didJwk = `did:jwk:${Buffer.from(JSON.stringify(publicKeyJwk)).toString('base64url')}`;
+
+        if (format === "jwt_vc_json") {
+          const { iat, nbf, exp, ...cleanStaticVc } = STATIC_JWT_VC;
+
+          const vcPayload = {
+            ...cleanStaticVc,
+            iss: didJwk,
+            sub: didJwk,
+            jti: `urn:uuid:${randomUUID()}`,
+            vc: {
+              ...STATIC_JWT_VC.vc,
+              credentialSubject: {
+                ...STATIC_JWT_VC.vc.credentialSubject,
+                id: didJwk,
+              },
+            },
+          };
+
+          credential = await new SignJWT(vcPayload)
+            .setProtectedHeader({ alg: 'ES256', typ: 'JWT', kid: didJwk })
+            .setIssuedAt()
+            .setNotBefore('0s')
+            .setExpirationTime('1y')
+            .sign(privateKey);
+        } else if (format === "vc+sd-jwt") {
+            credential = await createSdJwt(STATIC_SD_JWT_VC, privateKey, didJwk, didJwk);
+        } else if (format === "mso_mdoc") {
+            credential = STATIC_MDL_MDOC_SAMPLE_B64URL;
+        }
+    }
+  } catch (error) {
+    console.error("Signing failed:", error);
+    return res.status(500).json({ error: "signing_error" });
+  }
+
+  if (isV1) {
+    return res.json({
+      credentials: [ { credential } ],
+      credential_issuer: issuerUrl,
+    });
+  }
+
   return res.json({
-    format: "ldp_vc",
-    credential: STATIC_LDP_VC,
+    format,
+    credential,
     c_nonce: "mock_nonce_123",
-    c_nonce_expires_in: 86400
+    c_nonce_expires_in: 86400,
   });
 }

--- a/mock-issuer-service/src/credential/ldp-vc.js
+++ b/mock-issuer-service/src/credential/ldp-vc.js
@@ -1,0 +1,177 @@
+import jsonld from 'jsonld';
+import jsigs from 'jsonld-signatures';
+import { Ed25519Signature2018 } from '@digitalbazaar/ed25519-signature-2018';
+import { Ed25519VerificationKey2018 } from '@digitalbazaar/ed25519-verification-key-2018';
+
+const { AssertionProofPurpose } = jsigs.purposes;
+
+// Predefined contexts to avoid network calls
+const CONTEXTS = {
+  "https://www.w3.org/2018/credentials/v1": {
+    "@context": {
+      "@version": 1.1,
+      "@protected": true,
+      "id": "@id",
+      "type": "@type",
+      "VerifiableCredential": {
+        "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "cred": "https://www.w3.org/2018/credentials#",
+          "sec": "https://w3id.org/security#",
+          "issuer": {
+            "@id": "cred:issuer",
+            "@type": "@id"
+          },
+          "issuanceDate": {
+            "@id": "cred:issuanceDate",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+          },
+          "expirationDate": {
+            "@id": "cred:expirationDate",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+          },
+          "credentialStatus": {
+            "@id": "cred:credentialStatus",
+            "@type": "@id"
+          },
+          "credentialSubject": {
+            "@id": "cred:credentialSubject"
+          },
+          "proof": {
+            "@id": "sec:proof",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "VerifiablePresentation": {
+        "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+        "@context": {
+          "@version": 1.1,
+          "@protected": true,
+          "id": "@id",
+          "type": "@type",
+          "cred": "https://www.w3.org/2018/credentials#",
+          "sec": "https://w3id.org/security#",
+          "verifiableCredential": {
+            "@id": "cred:verifiableCredential",
+            "@type": "@id",
+            "@container": "@set"
+          },
+          "proof": {
+            "@id": "sec:proof",
+            "@type": "@id",
+            "@container": "@set"
+          }
+        }
+      },
+      "EcdsaSecp256k1Signature2019": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
+      "EcdsaSecp256r1Signature2019": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
+      "Ed25519Signature2018": "https://w3id.org/security#Ed25519Signature2018",
+      "RsaSignature2018": "https://w3id.org/security#RsaSignature2018",
+      "proof": {
+        "@id": "https://w3id.org/security#proof",
+        "@type": "@id",
+        "@container": "@set"
+      }
+    }
+  },
+  "https://w3id.org/security/v2": {
+    "@context": {
+      "id": "@id",
+      "type": "@type",
+      "sec": "https://w3id.org/security#",
+      "proof": "sec:proof",
+      "verificationMethod": { "@id": "sec:verificationMethod", "@type": "@id" },
+      "created": { "@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#dateTime" },
+      "proofPurpose": { "@id": "sec:proofPurpose", "@type": "@id" },
+      "jws": "sec:jws"
+    }
+  },
+  "https://w3id.org/security/v1": {
+    "@context": {
+      "id": "@id",
+      "type": "@type",
+      "sec": "https://w3id.org/security#",
+      "proof": "sec:proof",
+      "jws": "sec:jws",
+      "created": { "@id": "http://purl.org/dc/terms/created", "@type": "http://www.w3.org/2001/XMLSchema#dateTime" },
+      "verificationMethod": { "@id": "sec:verificationMethod", "@type": "@id" }
+    }
+  },
+  "https://piyush7034.github.io/my-files/farmer.json": {
+    "@context": {
+      "id": "@id",
+      "type": "@type",
+      "@vocab": "https://piyush7034.github.io/my-files/farmer.json#",
+      "fullName": "https://schema.org/name",
+      "mobileNumber": "https://schema.org/telephone",
+      "dateOfBirth": "https://schema.org/birthDate",
+      "landArea": "https://example.org/landArea",
+      "landOwnershipType": "https://example.org/landOwnershipType",
+      "address": "https://schema.org/address",
+      "village": "https://schema.org/addressLocality",
+      "district": "https://schema.org/addressRegion",
+      "farmProfile": "https://example.org/farmProfile",
+      "landRecord": "https://example.org/landRecord",
+      "surveyNumber": "https://example.org/surveyNumber",
+      "registry": "https://example.org/registry",
+      "office": "https://example.org/registryOffice",
+      "irrigation": "https://example.org/irrigation",
+      "source": "https://example.org/source",
+      "provider": "https://example.org/provider",
+      "cooperative": "https://example.org/cooperative",
+      "membership": "https://example.org/membership",
+      "membershipNumber": "https://example.org/membershipNumber",
+      "since": {
+        "@id": "https://example.org/memberSince",
+        "@type": "http://www.w3.org/2001/XMLSchema#date"
+      },
+      "crops": "https://example.org/crops",
+      "plots": "https://example.org/plots",
+      "soilType": "https://example.org/soilType",
+      "areaAcres": "https://example.org/areaAcres"
+    }
+  }
+};
+
+export const documentLoader = async (url) => {
+  const context = CONTEXTS[url];
+  if (context) {
+    return {
+      contextUrl: null,
+      documentUrl: url,
+      document: context
+    };
+  }
+  // Fallback to a mock for any other URL to avoid validation errors in some suites
+  return {
+    contextUrl: null,
+    documentUrl: url,
+    document: { "@context": {} }
+  };
+};
+
+export async function signLdpVc(credential, issuerDid) {
+  const key = await Ed25519VerificationKey2018.generate({
+    id: `${issuerDid}#key-0`,
+    controller: issuerDid
+  });
+
+  const suite = new Ed25519Signature2018({
+    key,
+    date: new Date().toISOString()
+  });
+
+  const signedVc = await jsigs.sign(credential, {
+    suite,
+    purpose: new AssertionProofPurpose(),
+    documentLoader
+  });
+
+  return signedVc;
+}

--- a/mock-issuer-service/src/credential/mdoc.js
+++ b/mock-issuer-service/src/credential/mdoc.js
@@ -1,0 +1,135 @@
+import * as cbor from 'cbor-x';
+import * as cose from 'cose-js';
+import { createHash, randomBytes } from 'node:crypto';
+
+const standardCbor = new cbor.Encoder({
+  useRecords: false,
+  useTag259ForMaps: false,
+  variableMapSize: true,
+});
+
+function sha256(data) {
+  return createHash('sha256').update(data).digest();
+}
+
+function taggedDateTime(date) {
+  return new cbor.Tag(date.toISOString(), 0);
+}
+
+function toCoseKey(publicKeyJwk) {
+  return new Map([
+    [1, 2], // kty: EC2
+    [-1, 1], // crv: P-256
+    [-2, Buffer.from(publicKeyJwk.x, 'base64url')],
+    [-3, Buffer.from(publicKeyJwk.y, 'base64url')],
+  ]);
+}
+
+function normalizeCoseHeaderMap(header) {
+  if (!header || header instanceof Map) {
+    return header;
+  }
+
+  return new Map(
+    Object.entries(header).map(([key, value]) => {
+      const numericKey = Number(key);
+      return [Number.isNaN(numericKey) ? key : numericKey, value];
+    }),
+  );
+}
+
+export async function createMdoc(privateKeyJwk, publicKeyJwk, docType, namespaces) {
+  const issuerSigned = {
+    nameSpaces: {},
+    issuerAuth: null
+  };
+
+  const valueDigests = {};
+
+  for (const ns of Object.keys(namespaces)) {
+    issuerSigned.nameSpaces[ns] = [];
+    valueDigests[ns] = new Map();
+    
+    const nsClaims = namespaces[ns];
+    let digestId = 0;
+    
+    for (const claim of Object.keys(nsClaims)) {
+      const salt = randomBytes(16);
+      
+      const item = {
+        digestID: digestId,
+        random: salt,
+        elementIdentifier: claim,
+        elementValue: nsClaims[claim]
+      };
+      
+      const encodedItem = standardCbor.encode(item);
+      const taggedItem = new cbor.Tag(encodedItem, 24);
+      issuerSigned.nameSpaces[ns].push(taggedItem);
+      
+      const digest = sha256(standardCbor.encode(taggedItem));
+      valueDigests[ns].set(digestId, digest);
+      
+      digestId++;
+    }
+  }
+
+  const mso = {
+    version: "1.0",
+    digestAlgorithm: "SHA-256",
+    valueDigests: valueDigests,
+    deviceKeyInfo: {
+      deviceKey: toCoseKey(publicKeyJwk)
+    },
+    docType: docType,
+    validityInfo: {
+      signed: taggedDateTime(new Date()),
+      validFrom: taggedDateTime(new Date()),
+      validUntil: taggedDateTime(new Date(Date.now() + 365 * 24 * 60 * 60 * 1000))
+    }
+  };
+
+  const msoCbor = standardCbor.encode(new cbor.Tag(standardCbor.encode(mso), 24));
+  
+  // Sign MSO with COSE
+  const signer = {
+    key: {
+      d: Buffer.from(privateKeyJwk.d, 'base64url'),
+      x: Buffer.from(privateKeyJwk.x, 'base64url'),
+      y: Buffer.from(privateKeyJwk.y, 'base64url')
+    }
+  };
+  
+  // For COSE_Sign1:
+  // headers.p contains protected headers
+  // headers.u contains unprotected headers
+  // signers is a single signer object
+  const headers = {
+    p: { alg: 'ES256' },
+    u: { kid: privateKeyJwk.kid }
+  };
+  
+  try {
+    // In cose-js 0.9.0, exports.create(headers, payload, signers, options)
+    // If signers is NOT an array, it creates a COSE_Sign1.
+    const signature = await cose.sign.create(headers, msoCbor, signer);
+    const decodedSignature = cbor.decode(signature);
+    if (decodedSignature?.tag === 18) {
+      const sign1 = decodedSignature.value;
+      sign1[1] = normalizeCoseHeaderMap(sign1[1]);
+      issuerSigned.issuerAuth = standardCbor.encode(sign1);
+    } else {
+      issuerSigned.issuerAuth = signature;
+    }
+  } catch (err) {
+    console.error("COSE signing failed:", err);
+    throw err;
+  }
+
+  const mdoc = {
+    docType: docType,
+    issuerSigned: issuerSigned
+  };
+
+  return standardCbor.encode(mdoc);
+}

--- a/mock-issuer-service/src/credential/offer.js
+++ b/mock-issuer-service/src/credential/offer.js
@@ -1,34 +1,74 @@
 import crypto from "crypto";
-import { ISSUER } from "../issuer-metadata.js";
+import { resolveIssuanceOptions } from "../issuance-options.js";
+import { authServerBaseUrl, issuerBaseUrl } from "../issuer-profile.js";
+import { preAuthCodeStore } from "../as/authz-store.js";
 
 export default function credentialOfferHandler(req, res) {
-  const issuer = ISSUER;
+  const options = resolveIssuanceOptions(req.query);
+  const flow = options.flow === "pdi" ? "pdi" : null;
+  const issuer = issuerBaseUrl(options.version, true, flow);
+  const authServer = authServerBaseUrl(
+    options.version,
+    true,
+    flow,
+  );
 
   // random issuer_state for this issuance session
   const issuerState = crypto.randomBytes(8).toString("hex");
 
-  // The credential_configuration_id that your mock issuer supports
-  const credentialConfigurations = [
-    // Uncomment the credential_configuration_id that you want to download.
+  let grantResponse = {};
 
-    "UniversityDegreeCredential",
-    // "JwtVerifiableCredential"
-  ];
+  if (options.flow === "pdi") {
+    grantResponse = {
+      authorization_code: {
+        issuer_state: issuerState,
+        authorization_server: authServer,
+      },
+      interaction_required: {
+        mode: "presentation_during_issuance",
+        endpoint: `${authServer}/interactive-authorization`,
+      },
+    };
+  } else if (options.flow === "pre-auth" || options.flow === "pre-auth-tx") {
+    const preAuthorizedCode = crypto.randomBytes(16).toString("hex");
+    let txCode = null;
+    
+    const grant = {
+      "pre-authorized_code": preAuthorizedCode,
+    };
+
+    if (options.flow === "pre-auth-tx") {
+      // Use the tx_code passed from the UI/Console
+      txCode = req.query.tx_code || "0000"; 
+      grant.tx_code = {
+        length: txCode.length,
+        input_mode: "numeric",
+        description: "Please enter the PIN displayed on the issuer console"
+      };
+    }
+
+    preAuthCodeStore.set(preAuthorizedCode, {
+      txCode,
+      configurationId: options.credentialDetails.configurationId,
+      scope: options.credentialDetails.scope
+    });
+
+    grantResponse = {
+      "urn:ietf:params:oauth:grant-type:pre-authorized_code": grant
+    };
+  } else {
+    grantResponse = {
+      authorization_code: {
+        issuer_state: issuerState,
+      },
+    };
+  }
 
   const response = {
     credential_issuer: issuer,
-
-    // NEW 1.1 field
     issuer_state: issuerState,
-
-    // as per spec: can be array or single object
-    credential_configuration_ids: credentialConfigurations,
-
-    grants: {
-      "authorization_code": {
-        issuer_state: issuerState
-      }
-    }
+    credential_configuration_ids: [options.credentialDetails.configurationId],
+    grants: grantResponse,
   };
 
   return res.json(response);

--- a/mock-issuer-service/src/credential/sd-jwt.js
+++ b/mock-issuer-service/src/credential/sd-jwt.js
@@ -1,0 +1,44 @@
+import { SignJWT } from 'jose';
+import { randomBytes, createHash } from 'node:crypto';
+
+function base64url(buffer) {
+  return buffer.toString('base64url');
+}
+
+function sha256(data) {
+  return createHash('sha256').update(data).digest();
+}
+
+export async function createSdJwt(payload, privateKey, issuer, holderDid) {
+  const disclosures = [];
+  const sdHashes = [];
+
+  const claimsToDisclose = Object.keys(payload).filter(k => k !== 'iss' && k !== 'sub' && k !== 'iat' && k !== 'exp' && k !== 'nbf' && k !== 'jti' && k !== 'vct');
+
+  const newPayload = { ...payload };
+  
+  for (const claim of claimsToDisclose) {
+    const salt = base64url(randomBytes(16));
+    const disclosureArray = [salt, claim, payload[claim]];
+    const disclosureJson = JSON.stringify(disclosureArray);
+    const disclosureB64 = Buffer.from(disclosureJson).toString('base64url');
+    disclosures.push(disclosureB64);
+    
+    const hash = base64url(sha256(disclosureB64));
+    sdHashes.push(hash);
+    delete newPayload[claim];
+  }
+
+  newPayload._sd = sdHashes.sort();
+  newPayload._sd_alg = 'sha-256';
+
+  const jwt = await new SignJWT(newPayload)
+    .setProtectedHeader({ alg: 'ES256', typ: 'vc+sd-jwt', kid: issuer })
+    .setIssuedAt()
+    .setIssuer(issuer)
+    .setSubject(holderDid)
+    .setExpirationTime('1y')
+    .sign(privateKey);
+
+  return jwt + '~' + disclosures.join('~') + '~';
+}

--- a/mock-issuer-service/src/credential/static-vc.js
+++ b/mock-issuer-service/src/credential/static-vc.js
@@ -15,6 +15,36 @@ export const STATIC_LDP_VC = {
     landOwnershipType: "Leased",
     primaryCropType: "Rice",
     secondaryCropType: "Pulses",
+    address: {
+      village: "Koppal",
+      district: "Koppal"
+    },
+    farmProfile: {
+      landRecord: {
+        surveyNumber: "SRV-2025-0091",
+        registry: {
+          office: "Koppal Land Records Office",
+          district: "Koppal",
+        },
+      },
+      irrigation: {
+        source: {
+          type: "Canal",
+          provider: "Tungabhadra Channel Board",
+        },
+      },
+    },
+    cooperative: {
+      membership: {
+        membershipNumber: "KOP-FARM-4421",
+        since: "2019-06-01",
+      },
+    },
+    crops: ["Rice", "Pulses", "Millet"],
+    plots: [
+      { soilType: "Alluvial", areaAcres: 15.5 },
+      { soilType: "Black", areaAcres: 10.25 }
+    ],
   },
   proof: {
     type: "Ed25519Signature2018",
@@ -41,7 +71,40 @@ export const STATIC_JWT_VC = {
       "id": "did:example:holder456",
       "employeeId": "E12345",
       "name": "Anup Kumar",
-      "role": "Software Engineer"
+      "role": "Software Engineer",
+      "address": {
+        "city": "Bengaluru",
+        "country": "India"
+      },
+      "nationalities": ["Indian", "Singaporean"],
+      "degrees": [
+        { "type": "B.Tech", "university": "IIT" },
+        { "type": "M.S.", "university": "NUS" }
+      ]
     }
   }
 };
+
+export const STATIC_SD_JWT_VC = {
+  vct: "EmployeeCredential",
+  employeeId: "E12345",
+  name: "Anup Kumar",
+  role: "Software Engineer",
+  department: "R&D",
+  location: "Bangalore"
+};
+
+export const STATIC_MDL_MDOC = {
+  "org.iso.18013.5.1": {
+    "given_name": "Anup",
+    "family_name": "Kumar",
+    "birth_date": "1990-01-01",
+    "issue_date": "2023-01-01",
+    "expiry_date": "2033-01-01",
+    "issuing_country": "IN",
+    "issuing_authority": "Ministry of Transport",
+    "document_number": "ABC123456"
+  }
+};
+
+export const STATIC_MDL_MDOC_SAMPLE_B64URL = "omdkb2NUeXBldW9yZy5pc28uMTgwMTMuNS4xLm1ETGxpc3N1ZXJTaWduZWSiamlzc3VlckF1dGiEQ6EBJqEYIVkB2TCCAdUwggF7oAMCAQICFBRDWWSBLltTWt65yytaZ01baoM9MAoGCCqGSM49BAMCMFkxCzAJBgNVBAYTAk1LMQ4wDAYDVQQIDAVNSy1LQTENMAsGA1UEBwwETW9jazENMAsGA1UECgwETW9jazENMAsGA1UECwwETU9jazENMAsGA1UEAwwETW9jazAeFw0yNDEwMjEwNzU2MTBaFw0yNTEwMjEwNzU2MTBaMFkxCzAJBgNVBAYTAk1LMQ4wDAYDVQQIDAVNSy1LQTENMAsGA1UEBwwETW9jazENMAsGA1UECgwETW9jazENMAsGA1UECwwETU9jazENMAsGA1UEAwwETW9jazBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABA8PMic1jzZYunhb2Ymq3eH2qEudb5rBnGMk1RAmFuLbPYBgFhDjdhK7j3ciE16-XfCFHnVEX8cANHw1_XjU2nejITAfMB0GA1UdDgQWBBQmaVJHKU-6Y7m6g6qolUJ3p94yhjAKBggqhkjOPQQDAgNIADBFAiEAwXQgNSUrhHIlPE1N24u5UCRwBTqYKKpJqBlC0niZRHgCIFryTL85LV-hab5RL4YiDpDeNOL6_YyiS-STfjrv-OL4WQJR2BhZAkymZ3ZlcnNpb25jMS4wb2RpZ2VzdEFsZ29yaXRobWdTSEEtMjU2Z2RvY1R5cGV1b3JnLmlzby4xODAxMy41LjEubURMbHZhbHVlRGlnZXN0c6Fxb3JnLmlzby4xODAxMy41LjGoAlggahyUDZzWwyVz1oYQSOSTOl3XfzVAAVi-ILLpwP3DMtUGWCBJiBVoqzuOj8ZRrOsV7DNFe0QBWplIKWMU3aILs8y6lwNYILzO8fswbC_wn7rQYO8eq91XotAltVllVzYTwyYHHWYIAVggHp8Y6cV73O670tvfMiyCZoxGczcYyfOh43Q8ahKpxxcEWCC75BhZBjDE1I4S5NLZAsaUmBERMZM9rMgZPkAzl45VeABYIIlDF4uT1D3MLGPsLL-kVBP0SHyxAYcAVf9SLYLUJUUgB1ggFuI0cmV1WwSJGv5VxI5a7Dsm6fIqr2MeIDBmYjIlZ0oFWCA88kOo8KNGtCpl2XH5CXMcgoE6D_fag9xjmPoLUcpgpG1kZXZpY2VLZXlJbmZvoWlkZXZpY2VLZXmkAQIgASFYIOMdpjABg7S1sJBCgdC4D6V237Jk_oGhMl_LInX0CFnGIlggPdyNKVXrSZb4CYQmoK6lX7Zux0DIBcnhJ9-_a7ZlYtdsdmFsaWRpdHlJbmZvo2ZzaWduZWTAdDIwMjQtMTAtMjFUMDg6MTE6MTNaaXZhbGlkRnJvbcB0MjAyNC0xMC0yMVQwODoxMToxM1pqdmFsaWRVbnRpbMB0MjAyNS0xMC0yMVQwODoxMToxM1pYQBZJtQ6yPA--sITjOK29mGLGKeG2DEx3qDHQEw99esCHwUnPJtobUfLGHhfmM0nawMZai21LXq5ZEdInOkEDSNRqbmFtZVNwYWNlc6Fxb3JnLmlzby4xODAxMy41LjGI2BhYaqRoZGlnZXN0SUQCZnJhbmRvbVBthSy1vmphqpoMYRe9Z0PncWVsZW1lbnRJZGVudGlmaWVyamlzc3VlX2RhdGVsZWxlbWVudFZhbHVleBsyMDI0LTEwLTIxVDA4OjExOjEzLjQ5NTQ3OFrYGFhrpGhkaWdlc3RJRAZmcmFuZG9tUNyXhXOZjmheiFyzYfhsl0ZxZWxlbWVudElkZW50aWZpZXJrZXhwaXJ5X2RhdGVsZWxlbWVudFZhbHVleBsyMDI1LTEwLTIxVDA4OjExOjEzLjQ5NTQ3OFrYGFjBpGhkaWdlc3RJRANmcmFuZG9tUCC-v7ARALJ2VFcYww9AbMhxZWxlbWVudElkZW50aWZpZXJyZHJpdmluZ19wcml2aWxlZ2VzbGVsZW1lbnRWYWx1ZXhqe2lzc3VlX2RhdGU9MjAyNC0xMC0yMVQwODoxMToxMy40OTU0NzhaLCB2ZWhpY2xlX2NhdGVnb3J5X2NvZGU9QSwgZXhwaXJ5X2RhdGU9MjAyNS0xMC0yMVQwODoxMToxMy40OTU0NzhafdgYWFekaGRpZ2VzdElEAWZyYW5kb21Q46GI__EQWetvvOYmVd-9b3FlbGVtZW50SWRlbnRpZmllcm9kb2N1bWVudF9udW1iZXJsZWxlbWVudFZhbHVlZDEyMzPYGFhVpGhkaWdlc3RJRARmcmFuZG9tUIO4lnDW2fm_Utg97twL9mJxZWxlbWVudElkZW50aWZpZXJvaXNzdWluZ19jb3VudHJ5bGVsZW1lbnRWYWx1ZWJNS9gYWFikaGRpZ2VzdElEAGZyYW5kb21QBYNczBataC2MR4om9FAnmHFlbGVtZW50SWRlbnRpZmllcmpiaXJ0aF9kYXRlbGVsZW1lbnRWYWx1ZWoxOTk0LTExLTA22BhYVKRoZGlnZXN0SUQHZnJhbmRvbVBJWZtW3VOzNRpXK0Dyf3LTcWVsZW1lbnRJZGVudGlmaWVyamdpdmVuX25hbWVsZWxlbWVudFZhbHVlZkpvc2VwaNgYWFWkaGRpZ2VzdElEBWZyYW5kb21QfzR7XZl5Fiz6lZ0oMqRhlnFlbGVtZW50SWRlbnRpZmllcmtmYW1pbHlfbmFtZWxlbGVtZW50VmFsdWVmQWdhdGhh";

--- a/mock-issuer-service/src/issuance-options.js
+++ b/mock-issuer-service/src/issuance-options.js
@@ -1,0 +1,67 @@
+const FLOW_OPTIONS = new Set(["normal", "pdi", "pre-auth", "pre-auth-tx"]);
+const VERSION_OPTIONS = new Set(["v1", "draft13"]);
+const CREDENTIAL_OPTIONS = new Set(["farmer", "employee", "sd-jwt", "mdoc"]);
+
+export const DEFAULT_ISSUANCE_OPTIONS = Object.freeze({
+  flow: "normal",
+  version: "v1",
+  credential: "farmer",
+});
+
+const CREDENTIAL_MAP = {
+  farmer: {
+    configurationId: "UniversityDegreeCredential",
+    format: "ldp_vc",
+    label: "Farmer Credential",
+    scope: "degree.read",
+    description: "LDP VC payload backed by the mock farmer dataset.",
+  },
+  employee: {
+    configurationId: "JwtVerifiableCredential",
+    format: "jwt_vc_json",
+    label: "Employee Credential",
+    scope: "jwt_vc_json.read",
+    description: "JWT VC payload backed by the mock employee dataset.",
+  },
+  "sd-jwt": {
+    configurationId: "SdJwtVerifiableCredential",
+    format: "vc+sd-jwt",
+    label: "SD-JWT Employee",
+    scope: "sd_jwt_vc.read",
+    description: "Selective Disclosure JWT VC for Employee.",
+  },
+  mdoc: {
+    configurationId: "MdocVerifiableCredential",
+    format: "mso_mdoc",
+    label: "Mobile Driving License",
+    scope: "mdoc.read",
+    description: "ISO 18013-5 Mobile Driving License (mDL) as mdoc.",
+  },
+};
+
+export function resolveIssuanceOptions(query = {}) {
+  const flow = FLOW_OPTIONS.has(query.flow) ? query.flow : DEFAULT_ISSUANCE_OPTIONS.flow;
+  const version = VERSION_OPTIONS.has(query.version)
+    ? query.version
+    : DEFAULT_ISSUANCE_OPTIONS.version;
+  const credential = CREDENTIAL_OPTIONS.has(query.credential)
+    ? query.credential
+    : DEFAULT_ISSUANCE_OPTIONS.credential;
+
+  return {
+    flow,
+    version,
+    credential,
+    credentialDetails: CREDENTIAL_MAP[credential],
+  };
+}
+
+export function buildOfferUrl(issuer, options) {
+  const params = new URLSearchParams({
+    flow: options.flow,
+    version: options.version,
+    credential: options.credential,
+  });
+
+  return `${issuer}/credential-offer?${params.toString()}`;
+}

--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -1,111 +1,254 @@
-export const ISSUER = "https://e4845fb4e9e7.ngrok-free.app";
+import {
+  ISSUER,
+  authServerBaseUrl,
+  hasExplicitVersion,
+  issuerBaseUrl,
+  resolveRequestVersion,
+} from "./issuer-profile.js";
+
+const BASE_CREDENTIAL_CONFIGURATIONS = {
+  UniversityDegreeCredential: {
+    format: "ldp_vc",
+    scope: "degree.read",
+    cryptographic_binding_methods_supported: ["jwk"],
+    proof_types_supported: {
+      jwt: {
+        proof_signing_alg_values_supported: ["RS256"],
+      },
+    },
+    credential_definition: {
+      type: ["VerifiableCredential", "FarmerCredential"],
+      "@context": ["https://www.w3.org/2018/credentials/v1"],
+    },
+    credential_metadata: {
+      display: [
+        { name: "Farmer Credential", locale: "en" },
+        { name: "किसान क्रेडेंशियल", locale: "hi" },
+      ],
+      claims: [
+        {
+          path: ["credentialSubject", "fullName"],
+          display: [
+            { name: "Full Name", locale: "en" },
+            { name: "पूरा नाम", locale: "hi" },
+          ],
+        },
+        {
+          path: ["credentialSubject", "mobileNumber"],
+          display: [{ name: "Mobile Number", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "dateOfBirth"],
+          display: [{ name: "Date of Birth", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "landArea"],
+          display: [{ name: "Land Area (acres)", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "landOwnershipType"],
+          display: [{ name: "Land Ownership", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "address", "village"],
+          display: [{ name: "Village", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "farmProfile", "landRecord", "surveyNumber"],
+          display: [{ name: "Survey Number", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "farmProfile", "landRecord", "registry", "office"],
+          display: [{ name: "Registry Office", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "farmProfile", "irrigation", "source", "type"],
+          display: [{ name: "Irrigation Source Type", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "cooperative", "membership", "membershipNumber"],
+          display: [{ name: "Cooperative Membership Number", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "crops", null],
+          display: [{ name: "Crops", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "plots", 0, "soilType"],
+          display: [{ name: "Primary Plot Soil", locale: "en" }],
+        },
+      ],
+    },
+  },
+  JwtVerifiableCredential: {
+    format: "jwt_vc_json",
+    scope: "jwt_vc_json.read",
+    cryptographic_binding_methods_supported: ["did:jwk"],
+    credential_signing_alg_values_supported: ["ES256"],
+    proof_types_supported: {
+      jwt: {
+        proof_signing_alg_values_supported: ["ES256", "RS256"],
+      },
+    },
+    credential_definition: {
+      type: ["VerifiableCredential", "EmployeeCredential"],
+    },
+    credential_metadata: {
+      display: [
+        { name: "Employee Credential", locale: "en" },
+        { name: "Kredensyal ng Empleyado", locale: "fil" },
+        { name: "कर्मचारी क्रेडेंशियल", locale: "hi" },
+        { name: "ಉದ್ಯೋಗಿ ರುಜುವಾತು", locale: "kn" },
+        { name: "பணியாளர் நற்சான்றிதழ்", locale: "ta" },
+        { name: "اعتماد الموظف", locale: "ar" },
+      ],
+      claims: [
+        {
+          path: ["credentialSubject", "employeeId"],
+          display: [
+            { name: "कर्मचारी पहचान", locale: "hi" },
+            { name: "Employee ID", locale: "en" },
+            { name: "ID ng Empleyado", locale: "fil" },
+            { name: "ಉದ್ಯೋಗಿ ಗುರುತು", locale: "kn" },
+            { name: "பணியாளர் அடையாளம்", locale: "ta" },
+            { name: "معرف الموظف", locale: "ar" },
+          ],
+        },
+        {
+          path: ["credentialSubject", "name"],
+          display: [
+            { name: "पूरा नाम", locale: "hi" },
+            { name: "Name", locale: "en" },
+            { name: "Buong Pangalan", locale: "fil" },
+            { name: "ಪೂರ್ಣ ಹೆಸರು", locale: "kn" },
+            { name: "முழு பெயர்", locale: "ta" },
+            { name: "الاسم الكامل", locale: "ar" },
+          ],
+        },
+        {
+          path: ["credentialSubject", "role"],
+          display: [
+            { name: "भूमिका", locale: "hi" },
+            { name: "Role", locale: "en" },
+            { name: "Tungkulin", locale: "fil" },
+            { name: "ಪಾತ್ರ", locale: "kn" },
+            { name: "பணிப்பொறுப்பு", locale: "ta" },
+            { name: "الدور الوظيفي", locale: "ar" },
+          ],
+        },
+        {
+          path: ["credentialSubject", "address", "city"],
+          display: [{ name: "City", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "nationalities", null],
+          display: [{ name: "Nationalities", locale: "en" }],
+        },
+        {
+          path: ["credentialSubject", "degrees", 0, "type"],
+          display: [{ name: "Primary Degree", locale: "en" }],
+        },
+      ],
+    },
+  },
+  SdJwtVerifiableCredential: {
+    format: "vc+sd-jwt",
+    scope: "sd_jwt_vc.read",
+    cryptographic_binding_methods_supported: ["did:jwk"],
+    credential_signing_alg_values_supported: ["ES256"],
+    proof_types_supported: {
+      jwt: {
+        proof_signing_alg_values_supported: ["ES256", "RS256"],
+      },
+    },
+    vct: "EmployeeCredential",
+    credential_metadata: {
+      display: [
+        { name: "SD-JWT Employee Credential", locale: "en" },
+      ],
+      claims: [
+        {
+          path: ["employeeId"],
+          display: [{ name: "Employee ID", locale: "en" }],
+        },
+        {
+          path: ["name"],
+          display: [{ name: "Name", locale: "en" }],
+        },
+      ],
+    },
+  },
+  MdocVerifiableCredential: {
+    format: "mso_mdoc",
+    scope: "mdoc.read",
+    cryptographic_binding_methods_supported: ["jwk"],
+    credential_signing_alg_values_supported: ["ES256"],
+    doctype: "org.iso.18013.5.1.mDL",
+    credential_metadata: {
+      display: [
+        { name: "Mobile Driving License", locale: "en" },
+      ],
+      claims: [
+        {
+          path: ["org.iso.18013.5.1", "given_name"],
+          display: [{ name: "Given Name", locale: "en" }],
+        },
+        {
+          path: ["org.iso.18013.5.1", "family_name"],
+          display: [{ name: "Family Name", locale: "en" }],
+        },
+      ],
+    },
+  },
+};
+
+function toDraft13Configuration(configuration) {
+  const { credential_metadata, ...rest } = configuration;
+
+  return {
+    ...rest,
+    display: credential_metadata?.display || [],
+    claims: credential_metadata?.claims || [],
+  };
+}
+
+function buildCredentialConfigurations(version) {
+  const isV1 = version === "v1";
+
+  return Object.fromEntries(
+    Object.entries(BASE_CREDENTIAL_CONFIGURATIONS).map(([id, configuration]) => [
+      id,
+      isV1 ? configuration : toDraft13Configuration(configuration),
+    ]),
+  );
+}
+
+export { ISSUER };
 
 export default function issuerMetadata(req, res) {
-  res.json({
-    credential_issuer: ISSUER,
+  const version = resolveRequestVersion(req);
+  const explicitVersion = hasExplicitVersion(req);
+  const flow = req.params?.flow === "pdi" ? "pdi" : null;
+  const credentialIssuer = issuerBaseUrl(version, explicitVersion, flow);
+  const authorizationServer = authServerBaseUrl(version, explicitVersion, flow);
+  const isV1 = version === "v1";
 
-    authorization_servers: [
-      `${ISSUER}/as`
-    ],
-
-    credential_endpoint: `${ISSUER}/credential`,
-
-    credential_configurations_supported: {
-      "UniversityDegreeCredential": {
-        format: "ldp_vc",
-        scope: "degree.read",
-        cryptographic_binding_methods_supported: ["jwk"],
-        proof_types_supported: {
-          jwt: {
-            proof_signing_alg_values_supported: ["RS256"]
-          }
-        },
-        credential_definition: {
-            type: ["VerifiableCredential", "UniversityDegreeCredential"],
-            context: [
-              "https://www.w3.org/2018/credentials/v1",
-              
-            ]
-        }
-      },
-      "JwtVerifiableCredential": {
-        format: "jwt_vc_json",
-        scope: "jwt_vc_json.read",
-        "display": [
-          {
-            name: "Employee Credential",
-            locale: "en"
-          },
-          {
-            name: "Kredensyal ng Empleyado",
-            locale: "fil"
-          },
-          {
-            name: "कर्मचारी क्रेडेंशियल",
-            locale: "hi"
-          },
-          {
-            name: "ಉದ್ಯೋಗಿ ರುಜುವಾತು",
-            locale: "kn"
-          },
-          {
-            name: "பணியாளர் நற்சான்றிதழ்",
-            locale: "ta"
-          },
-          {
-            name: "اعتماد الموظف",
-            locale: "ar"
-          }
-      ],
-        cryptographic_binding_methods_supported: ["did:jwk"],
-        credential_signing_alg_values_supported: ["ES256"],
-        proof_types_supported: {
-          jwt: {
-            proof_signing_alg_values_supported: ["ES256", "RS256"]
-          }
-        },
-        credential_definition: {
-          type: ["VerifiableCredential", "EmployeeCredential"],
-          credentialSubject: {
-            "employeeId": {
-              "display": [
-                { name: "कर्मचारी पहचान", locale: "hi" },
-                { name: "Employee ID", locale: "en" },
-                { name: "ID ng Empleyado", locale: "fil" },
-                { name: "ಉದ್ಯೋಗಿ ಗುರುತು", locale: "kn" },
-                { name: "பணியாளர் அடையாளம்", locale: "ta" },
-                { name: "معرف الموظف", locale: "ar" },
-              ]
-            },
-            "name": {
-              "display": [
-                { name: "पूरा नाम", locale: "hi" },
-                { name: "Name", locale: "en" },
-                { name: "Buong Pangalan", locale: "fil" },
-                { name: "ಪೂರ್ಣ ಹೆಸರು", locale: "kn" },
-                { name: "முழு பெயர்", locale: "ta" },
-                { name: "الاسم الكامل", locale: "ar" },
-              ]
-            },
-            "role": {
-              "display": [
-                { name: "भूमिका", locale: "hi" },
-                { name: "Role", locale: "en" },
-                { name: "Tungkulin", locale: "fil" },
-                { name: "ಪಾತ್ರ", locale: "kn" },
-                { name: "பணிப்பொறுப்பு", locale: "ta" },
-                { name: "الدور الوظيفي", locale: "ar" },
-              ]
-            }
-          }
-        }
-      }
-    },
-
+  const response = {
+    credential_issuer: credentialIssuer,
+    authorization_servers: [authorizationServer],
+    credential_endpoint: `${credentialIssuer}/credential`,
+    credential_configurations_supported: buildCredentialConfigurations(version),
     grants: {
       authorization_code: {
-        issuer_state: true
+        issuer_state: true,
       },
+      "urn:ietf:params:oauth:grant-type:pre-authorized_code": {},
     },
-  });
+  };
+
+  if (isV1) {
+    response.nonce_endpoint = `${credentialIssuer}/nonce`;
+  }
+
+  res.json(response);
 }

--- a/mock-issuer-service/src/issuer-profile.js
+++ b/mock-issuer-service/src/issuer-profile.js
@@ -1,0 +1,40 @@
+export const ISSUER = "https://3ab7-2405-201-801a-9ad1-4dac-ced7-72c1-fa74.ngrok-free.app";
+
+export function normalizeSpecVersion(version) {
+  return version === "draft13" ? "draft13" : "v1";
+}
+
+export function resolveRequestVersion(req) {
+  return normalizeSpecVersion(req.params?.version || req.query?.version);
+}
+
+export function hasExplicitVersion(req) {
+  return Boolean(req.params?.version || req.query?.version);
+}
+
+export function normalizeFlow(flow) {
+  return flow === "pdi" ? "pdi" : null;
+}
+
+export function issuerBaseUrl(version, explicit = true, flow = null) {
+  const normalized = normalizeSpecVersion(version);
+  const normalizedFlow = normalizeFlow(flow);
+
+  if (!explicit) {
+    return normalizedFlow ? `${ISSUER}/${normalizedFlow}` : ISSUER;
+  }
+
+  const base = `${ISSUER}/${normalized}`;
+  return normalizedFlow ? `${base}/${normalizedFlow}` : base;
+}
+
+export function authServerBaseUrl(version, explicit = true, flow = null) {
+  const base = issuerBaseUrl(version, explicit);
+  const normalizedFlow = normalizeFlow(flow);
+
+  if (normalizedFlow) {
+    return `${base}/${normalizedFlow}/as`;
+  }
+
+  return `${base}/as`;
+}

--- a/mock-issuer-service/src/nonce.js
+++ b/mock-issuer-service/src/nonce.js
@@ -1,0 +1,17 @@
+import { randomUUID } from 'node:crypto';
+import { hasExplicitVersion, resolveRequestVersion } from "./issuer-profile.js";
+
+export default function nonceHandler(req, res) {
+  if (hasExplicitVersion(req) && resolveRequestVersion(req) === "draft13") {
+    return res.status(404).json({
+      error: "unsupported_endpoint",
+      error_description: "nonce endpoint is not available for the draft13 issuer profile",
+    });
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.json({
+    c_nonce: randomUUID(),
+    c_nonce_expires_in: 300,
+  });
+}

--- a/mock-issuer-service/src/qr.js
+++ b/mock-issuer-service/src/qr.js
@@ -1,20 +1,451 @@
 import QRCode from "qrcode";
 import { ISSUER } from "./issuer-metadata.js";
+import { buildOfferUrl, resolveIssuanceOptions } from "./issuance-options.js";
 
-export default async function qrHandler(req, res) {
-  const offerUri =
-    `${ISSUER}/credential-offer`;
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
 
-  // According to spec: openid-credential-offer://?credential_offer_uri=<URL>
-  const qrData =
-    "openid-credential-offer://?credential_offer_uri=" +
-    encodeURIComponent(offerUri);
+function buildQrPayload(options, pin = null) {
+  let offerUri = buildOfferUrl(ISSUER, options);
+  if (pin) {
+    const url = new URL(offerUri);
+    url.searchParams.set("tx_code", pin);
+    offerUri = url.toString();
+  }
+
+  return {
+    offerUri,
+    qrData:
+      "openid-credential-offer://?credential_offer_uri=" +
+      encodeURIComponent(offerUri),
+  };
+}
+
+function optionButton(name, value, currentValue, label, hint) {
+  const checked = value === currentValue ? "checked" : "";
+
+  return `
+    <label class="toggle-option">
+      <input type="radio" name="${escapeHtml(name)}" value="${escapeHtml(value)}" ${checked} />
+      <span>${escapeHtml(label)}</span>
+      <small>${escapeHtml(hint)}</small>
+    </label>
+  `;
+}
+
+function renderPage(options, pin = null) {
+  const { offerUri } = buildQrPayload(options, pin);
+
+  const queryParams = new URLSearchParams({
+    flow: options.flow,
+    version: options.version,
+    credential: options.credential
+  });
+  if (pin) queryParams.set("tx_code", pin);
+
+  const qrImageUrl = `/qr/image?${queryParams.toString()}`;
+  const offerPreviewUrl = `/credential-offer?${queryParams.toString()}`;
+
+  const flowLabels = {
+    normal: "Normal (Auth Code)",
+    pdi: "PDI (Presentation)",
+    "pre-auth": "Pre-Auth",
+    "pre-auth-tx": "Pre-Auth + TX Code"
+  };
+  const flowLabel = flowLabels[options.flow] || options.flow;
+  const versionLabel = options.version === "draft13" ? "Draft 13" : "V1";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mock Issuer Console</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --page-bg: #f4f7f5;
+        --surface: #ffffff;
+        --surface-muted: #ebf1ec;
+        --text: #15231b;
+        --text-muted: #537161;
+        --border: #c8d6cc;
+        --accent: #176b52;
+        --accent-strong: #0f4f3d;
+        --accent-soft: #d8ece4;
+        --highlight: #d29a26;
+      }
+
+      * { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: linear-gradient(180deg, #eff5f1 0%, var(--page-bg) 100%);
+        color: var(--text);
+      }
+
+      main {
+        max-width: 1160px;
+        margin: 0 auto;
+        padding: 32px 20px 40px;
+      }
+
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.1fr) minmax(320px, 420px);
+        gap: 24px;
+        align-items: start;
+      }
+
+      .hero-main {
+        display: grid;
+        gap: 24px;
+        align-content: start;
+      }
+
+      .intro {
+        padding: 8px 0 0;
+      }
+
+      h1 {
+        margin: 0 0 12px;
+        font-size: clamp(32px, 5vw, 54px);
+        line-height: 1.02;
+      }
+
+      .intro p {
+        max-width: 58ch;
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 17px;
+        line-height: 1.6;
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 28px;
+      }
+
+      .summary-item {
+        padding: 14px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.82);
+      }
+
+      .summary-item strong,
+      .panel h2,
+      .preview h2 {
+        display: block;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+        color: var(--text-muted);
+        margin-bottom: 8px;
+      }
+
+      .summary-item span {
+        display: block;
+        font-size: 18px;
+        font-weight: 700;
+      }
+
+      .panel,
+      .preview {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface);
+      }
+
+      .panel {
+        padding: 24px;
+      }
+
+      .control-group + .control-group {
+        margin-top: 24px;
+      }
+
+      .control-group p {
+        margin: 0 0 12px;
+        color: var(--text-muted);
+        line-height: 1.5;
+      }
+
+      .toggle-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+      }
+
+      .toggle-option {
+        display: block;
+        padding: 14px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: var(--surface-muted);
+        cursor: pointer;
+      }
+
+      .toggle-option input {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+      }
+
+      .toggle-option span {
+        display: block;
+        font-size: 16px;
+        font-weight: 700;
+      }
+
+      .toggle-option small {
+        display: block;
+        margin-top: 6px;
+        color: var(--text-muted);
+        line-height: 1.5;
+      }
+
+      .toggle-option:has(input:checked) {
+        border-color: var(--accent);
+        background: var(--accent-soft);
+        box-shadow: inset 0 0 0 1px var(--accent);
+      }
+
+      .toggle-option:has(input:focus-visible) {
+        outline: 2px solid rgba(23, 107, 82, 0.28);
+        outline-offset: 2px;
+      }
+
+      .preview {
+        padding: 24px;
+      }
+
+      .qr-shell {
+        display: grid;
+        justify-items: center;
+        gap: 18px;
+        padding: 22px;
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        background: linear-gradient(180deg, #ffffff 0%, #f4f8f5 100%);
+      }
+
+      .qr-shell img {
+        width: min(100%, 320px);
+        height: auto;
+        border-radius: 8px;
+        background: #fff;
+      }
+
+      .callout {
+        margin: 0;
+        color: var(--text-muted);
+        text-align: center;
+        line-height: 1.5;
+      }
+
+      .meta-list {
+        margin: 18px 0 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 12px;
+      }
+
+      .meta-list li {
+        padding: 12px 0;
+        border-top: 1px solid var(--border);
+      }
+
+      .meta-list li:first-child {
+        border-top: 0;
+        padding-top: 0;
+      }
+
+      .meta-list strong {
+        display: block;
+        margin-bottom: 6px;
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+        color: var(--text-muted);
+      }
+
+      code {
+        display: block;
+        white-space: pre-wrap;
+        word-break: break-word;
+        padding: 10px 12px;
+        border-radius: 8px;
+        background: #10251d;
+        color: #effbf4;
+        font-size: 12px;
+        line-height: 1.55;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 20px;
+      }
+
+      .button-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 42px;
+        padding: 0 14px;
+        border: 1px solid var(--accent);
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 700;
+        color: var(--accent-strong);
+        background: white;
+      }
+
+      .button-link.primary {
+        background: var(--accent);
+        color: white;
+      }
+
+      .footer-note {
+        margin-top: 20px;
+        color: var(--text-muted);
+        font-size: 14px;
+        line-height: 1.6;
+      }
+
+      @media (max-width: 920px) {
+        .hero,
+        .workspace {
+          grid-template-columns: 1fr;
+        }
+
+        .summary-grid,
+        .toggle-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <section class="hero">
+        <div class="hero-main">
+          <div class="intro">
+            <h1>Build the exact QR experience you want to test.</h1>
+            <p>Switch flow, version, and credential type, then scan.</p>
+            <div class="summary-grid">
+              <div class="summary-item">
+                <strong>Auth flow</strong>
+                <span>${escapeHtml(flowLabel)}</span>
+              </div>
+              <div class="summary-item">
+                <strong>Issuer profile</strong>
+                <span>${escapeHtml(versionLabel)}</span>
+              </div>
+              <div class="summary-item">
+                <strong>Credential</strong>
+                <span>${escapeHtml(options.credentialDetails.label)}</span>
+              </div>
+            </div>
+          </div>
+
+          <form class="panel" id="issuer-controls">
+            <div class="control-group">
+              <h2>Authorization flow</h2>
+              <div class="toggle-grid">
+                ${optionButton("flow", "normal", options.flow, "Normal", "Auth Code flow")}
+                ${optionButton("flow", "pre-auth", options.flow, "Pre-Auth", "Pre-Authorized Code flow")}
+                ${optionButton("flow", "pre-auth-tx", options.flow, "Pre-Auth + TX", "Pre-Auth with 4-digit PIN")}
+                ${optionButton("flow", "pdi", options.flow, "PDI", "Presentation during issuance")}
+              </div>
+            </div>
+
+            <div class="control-group">
+              <h2>Spec version</h2>
+              <div class="toggle-grid">
+                ${optionButton("version", "v1", options.version, "V1", "Final issuer profile")}
+                ${optionButton("version", "draft13", options.version, "Draft 13", "Legacy issuer profile")}
+              </div>
+            </div>
+
+            <div class="control-group">
+              <h2>Credential type</h2>
+              <div class="toggle-grid">
+                ${optionButton("credential", "farmer", options.credential, "Farmer credential", "LDP VC")}
+                ${optionButton("credential", "employee", options.credential, "Employee credential", "JWT VC")}
+                ${optionButton("credential", "sd-jwt", options.credential, "SD-JWT Employee", "Selective Disclosure")}
+                ${optionButton("credential", "mdoc", options.credential, "Mobile DL", "ISO 18013-5 mdoc")}
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <aside class="preview">
+          <h2>Live QR</h2>
+          <div class="qr-shell">
+            <img src="${escapeHtml(qrImageUrl)}" alt="Credential offer QR code" />
+            <p class="callout">Scan this from a wallet. Every toggle updates the encoded credential offer URI.</p>
+          </div>
+          <ul class="meta-list">
+            ${pin ? `
+            <li>
+              <strong style="color: var(--highlight);">Transaction PIN (TX Code)</strong>
+              <code style="font-size: 24px; text-align: center; letter-spacing: 4px;">${escapeHtml(pin)}</code>
+              <small style="display: block; margin-top: 8px; color: var(--text-muted);">This PIN is delivered out-of-band. Enter this in your wallet when prompted.</small>
+            </li>
+            ` : ""}
+            <li>
+              <strong>Offer URI</strong>
+              <code>${escapeHtml(offerUri)}</code>
+            </li>
+            <li>
+              <strong>Credential profile</strong>
+              <code>${escapeHtml(options.credentialDetails.configurationId)} | ${escapeHtml(options.credentialDetails.format)}</code>
+            </li>
+          </ul>
+          <div class="actions">
+            <a class="button-link primary" href="${escapeHtml(qrImageUrl)}" target="_blank" rel="noreferrer">Open Raw QR</a>
+            <a class="button-link" href="${escapeHtml(offerPreviewUrl)}" target="_blank" rel="noreferrer">Open Offer JSON</a>
+          </div>
+          <p class="footer-note">PDI mode keeps the authorization code grant but also advertises the interactive authorization endpoint for presentation-driven testing.</p>
+        </aside>
+      </section>
+    </main>
+
+    <script>
+      const form = document.getElementById("issuer-controls");
+      form.addEventListener("change", () => {
+        const data = new FormData(form);
+        const params = new URLSearchParams(data);
+        window.location.search = params.toString();
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+export async function qrImageHandler(req, res) {
+  const options = resolveIssuanceOptions(req.query);
+  const pin = req.query.tx_code;
+  const { qrData } = buildQrPayload(options, pin);
 
   try {
     const png = await QRCode.toBuffer(qrData, {
       type: "png",
       width: 400,
-      errorCorrectionLevel: "M"
+      errorCorrectionLevel: "M",
     });
 
     res.setHeader("Content-Type", "image/png");
@@ -23,4 +454,23 @@ export default async function qrHandler(req, res) {
     console.error(err);
     res.status(500).json({ error: "QR generation failed" });
   }
+}
+
+export default async function qrPageHandler(req, res) {
+  const options = resolveIssuanceOptions(req.query);
+  let pin = req.query.tx_code;
+
+  if (options.flow === "pre-auth-tx" && !pin) {
+    pin = Math.floor(1000 + Math.random() * 9000).toString();
+    const params = new URLSearchParams(req.query);
+    params.set("tx_code", pin);
+    return res.redirect(`/qr?${params.toString()}`);
+  } else if (options.flow !== "pre-auth-tx" && pin) {
+    const params = new URLSearchParams(req.query);
+    params.delete("tx_code");
+    return res.redirect(`/qr?${params.toString()}`);
+  }
+
+  res.setHeader("Content-Type", "text/html; charset=utf-8");
+  res.send(renderPage(options, pin));
 }

--- a/mock-issuer-service/src/server.js
+++ b/mock-issuer-service/src/server.js
@@ -5,12 +5,13 @@ import cors from "cors";
 import authServerMetadata from "./as/metadata.js";
 import credentialOfferHandler from "./credential/offer.js";
 import issuerMetadata from "./issuer-metadata.js";
-import qrHandler from "./qr.js";
+import qrPageHandler, { qrImageHandler } from "./qr.js";
 import authorizeHandler from "./as/authorize.js";
 import interactiveAuthorizationHandler from "./as/interactive-authorization.js";
 import tokenHandler from "./as/token.js";
 import credentialHandler from "./credential/endpoint.js";
 import loginHandler from "./as/login.js";
+import nonceHandler from "./nonce.js";
 
 const app = express();
 app.use(express.urlencoded({ extended: true }));
@@ -21,10 +22,14 @@ app.use(cors());
 
 
 // ---- QR CODE ---- //
-app.get("/qr", qrHandler);
+app.get("/qr", qrPageHandler);
+app.get("/qr/image", qrImageHandler);
 
 // ---- WELL-KNOWN ---- //
 app.get("/.well-known/openid-credential-issuer", issuerMetadata);
+app.get("/:flow(pdi)/.well-known/openid-credential-issuer", issuerMetadata);
+app.get("/:version(v1|draft13)/.well-known/openid-credential-issuer", issuerMetadata);
+app.get("/:version(v1|draft13)/:flow(pdi)/.well-known/openid-credential-issuer", issuerMetadata);
 
 
 // ------------------------------
@@ -32,6 +37,18 @@ app.get("/.well-known/openid-credential-issuer", issuerMetadata);
 // ------------------------------
 app.get(
     "/as/.well-known/oauth-authorization-server",
+    authServerMetadata
+  );
+app.get(
+    "/:flow(pdi)/as/.well-known/oauth-authorization-server",
+    authServerMetadata
+  );
+app.get(
+    "/:version(v1|draft13)/as/.well-known/oauth-authorization-server",
+    authServerMetadata
+  );
+app.get(
+    "/:version(v1|draft13)/:flow(pdi)/as/.well-known/oauth-authorization-server",
     authServerMetadata
   );
 
@@ -45,14 +62,35 @@ app.get("/credential-offer", credentialOfferHandler);
 // ---- AUTHORIZATION SERVER ---- //
 // app.get("/as/authorize", authorizeHandler);
 app.post("/as/interactive-authorization", interactiveAuthorizationHandler);
+app.post("/:flow(pdi)/as/interactive-authorization", interactiveAuthorizationHandler);
+app.post("/:version(v1|draft13)/as/interactive-authorization", interactiveAuthorizationHandler);
+app.post("/:version(v1|draft13)/:flow(pdi)/as/interactive-authorization", interactiveAuthorizationHandler);
 app.post("/as/token", tokenHandler);
+app.post("/:flow(pdi)/as/token", tokenHandler);
+app.post("/:version(v1|draft13)/as/token", tokenHandler);
+app.post("/:version(v1|draft13)/:flow(pdi)/as/token", tokenHandler);
 app.get("/as/authorize", authorizeHandler);
+app.get("/:flow(pdi)/as/authorize", authorizeHandler);
+app.get("/:version(v1|draft13)/as/authorize", authorizeHandler);
+app.get("/:version(v1|draft13)/:flow(pdi)/as/authorize", authorizeHandler);
 
 // login form handler
 app.post("/as/login", express.urlencoded({ extended: true }), loginHandler);
+app.post("/:flow(pdi)/as/login", express.urlencoded({ extended: true }), loginHandler);
+app.post("/:version(v1|draft13)/as/login", express.urlencoded({ extended: true }), loginHandler);
+app.post("/:version(v1|draft13)/:flow(pdi)/as/login", express.urlencoded({ extended: true }), loginHandler);
 
 // ---- CREDENTIAL ENDPOINT ---- //
 app.post("/credential", credentialHandler);
+app.post("/:flow(pdi)/credential", credentialHandler);
+app.post("/:version(v1|draft13)/credential", credentialHandler);
+app.post("/:version(v1|draft13)/:flow(pdi)/credential", credentialHandler);
+
+// ---- NONCE ENDPOINT (OID4VCI 1.0) ---- //
+app.post("/nonce", nonceHandler);
+app.post("/:flow(pdi)/nonce", nonceHandler);
+app.post("/:version(v1|draft13)/nonce", nonceHandler);
+app.post("/:version(v1|draft13)/:flow(pdi)/nonce", nonceHandler);
 
 // ---- HTTPS SERVER ---- //
 const options = {


### PR DESCRIPTION
## What does this PR do?
Add OID4VCI v1-aware issuer flows to the mock issuer service while keeping draft13 support available from the same service.

This updates issuer and authorization metadata routing, adds nonce support for the v1 profile, extends QR and offer generation with version and credential options, and adds issuance handlers for LDP VC, JWT VC, SD-JWT, and mdoc credentials.

## Related Issue
Not provided.

## Type of Change
- [x] feat   — new feature
- [ ] fix    — bug fix
- [ ] refactor
- [ ] chore / docs / test

## Checklist
- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [x] No unrelated changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-format credential support added (LDP‑VC, JWT‑VC, SD‑JWT, mdoc)
  * Pre-authorized code grant (optional PIN/tx_code) and PDI flow for issuance
  * Multi-version/profile-aware endpoints and dynamic issuer/auth-server URLs
  * QR console and image endpoint enhanced with configurable flow/version/credential options
  * New nonce endpoint and expanded credential offer/offer‑URL handling

* **Documentation**
  * README updated to list newly supported credential formats
<!-- end of auto-generated comment: release notes by coderabbit.ai -->