### PR TITLE
#644 fix(metadata): add logo to credential type display

### DIFF
--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -22,8 +22,14 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     },
     credential_metadata: {
       display: [
-        { name: "Farmer Credential", locale: "en" },
-        { name: "किसान क्रेडेंशियल", locale: "hi" },
+        { name: "Farmer Credential", locale: "en" ,logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        }},
+        { name: "किसान क्रेडेंशियल", locale: "hi",logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        } },
       ],
       claims: [
         {
@@ -95,13 +101,32 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     },
     credential_metadata: {
       display: [
-        { name: "Employee Credential", locale: "en" },
-        { name: "Kredensyal ng Empleyado", locale: "fil" },
-        { name: "कर्मचारी क्रेडेंशियल", locale: "hi" },
-        { name: "ಉದ್ಯೋಗಿ ರುಜುವಾತು", locale: "kn" },
-        { name: "பணியாளர் நற்சான்றிதழ்", locale: "ta" },
-        { name: "اعتماد الموظف", locale: "ar" },
+        { name: "Employee Credential", locale: "en",logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        } },
+        { name: "Kredensyal ng Empleyado", locale: "fil" ,logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        }},
+        { name: "कर्मचारी क्रेडेंशियल", locale: "hi" ,logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        }},
+        { name: "ಉದ್ಯೋಗಿ ರುಜುವಾತು", locale: "kn",logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        } },
+        { name: "பணியாளர் நற்சான்றிதழ்", locale: "ta" ,logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        }},
+        { name: "اعتماد الموظف", locale: "ar",logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        } },
       ],
+
       claims: [
         {
           path: ["credentialSubject", "employeeId"],
@@ -164,7 +189,10 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     vct: "EmployeeCredential",
     credential_metadata: {
       display: [
-        { name: "SD-JWT Employee Credential", locale: "en" },
+        { name: "SD-JWT Employee Credential", locale: "en",logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        } },
       ],
       claims: [
         {
@@ -186,8 +214,12 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     doctype: "org.iso.18013.5.1.mDL",
     credential_metadata: {
       display: [
-        { name: "Mobile Driving License", locale: "en" },
+        { name: "Mobile Driving License", locale: "en" ,logo: {
+          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          alt_text: "a square logo of a MOSIP"
+        }},
       ],
+
       claims: [
         {
           path: ["org.iso.18013.5.1", "given_name"],
@@ -213,8 +245,9 @@ function toDraft13Configuration(configuration) {
 }
 
 function buildCredentialConfigurations(version) {
-  const isV1 = version === "v1";
 
+  const isV1 = version === "v1";
+  
   return Object.fromEntries(
     Object.entries(BASE_CREDENTIAL_CONFIGURATIONS).map(([id, configuration]) => [
       id,

--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -23,11 +23,11 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     credential_metadata: {
       display: [
         { name: "Farmer Credential", locale: "en" ,logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         }},
         { name: "किसान क्रेडेंशियल", locale: "hi",logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         } },
       ],
@@ -102,27 +102,27 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     credential_metadata: {
       display: [
         { name: "Employee Credential", locale: "en",logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         } },
         { name: "Kredensyal ng Empleyado", locale: "fil" ,logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         }},
         { name: "कर्मचारी क्रेडेंशियल", locale: "hi" ,logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         }},
         { name: "ಉದ್ಯೋಗಿ ರುಜುವಾತು", locale: "kn",logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         } },
         { name: "பணியாளர் நற்சான்றிதழ்", locale: "ta" ,logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         }},
         { name: "اعتماد الموظف", locale: "ar",logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         } },
       ],
@@ -190,7 +190,7 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     credential_metadata: {
       display: [
         { name: "SD-JWT Employee Credential", locale: "en",logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         } },
       ],
@@ -215,7 +215,7 @@ const BASE_CREDENTIAL_CONFIGURATIONS = {
     credential_metadata: {
       display: [
         { name: "Mobile Driving License", locale: "en" ,logo: {
-          url: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
+          uri: "https://inji.github.io/inji-config/logos/mosipid-logo.png",
           alt_text: "a square logo of a MOSIP"
         }},
       ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logo support to credential display entries. Farmer (University Degree), Employee, SD‑JWT Employee, and Mobile Driving License credentials now show logos in their display UIs across multiple languages (English, Hindi, Filipino, Kannada, Tamil, Arabic), improving visual identity, recognition, and consistency across localized credential views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->