### PR TITLE
feat(mock-service) : Add Pushed Authorization Request in mock-issuer

### DIFF
--- a/mock-issuer-service/src/as/authorize.js
+++ b/mock-issuer-service/src/as/authorize.js
@@ -1,7 +1,12 @@
+import crypto from "crypto";
 import fs from "fs";
 import path from "path";
 import { hasExplicitVersion, resolveRequestVersion } from "../issuer-profile.js";
-import { parRequestStore } from "./authz-store.js";
+import { parRequestStore, loginTransactionStore } from "./authz-store.js";
+
+// A login transaction binds the server-trusted authorization-request params to an
+// opaque id, so the browser cannot tamper with them via the login form's hidden fields.
+const LOGIN_TXN_EXPIRES_IN = 300; // seconds
 
 export default function authorizeHandler(req, res) {
   let {
@@ -17,7 +22,7 @@ export default function authorizeHandler(req, res) {
 
   // PAR (RFC 9126): if a request_uri is supplied, resolve the pushed parameters
   if (request_uri) {
-    console.log("Authorize via PAR — resolving request_uri:", request_uri);
+    console.log(`Authorize via PAR — resolving request_uri …${request_uri.slice(-8)}`);
     const stored = parRequestStore.get(request_uri);
     if (!stored) {
       return res.status(400).send("invalid or unknown request_uri");
@@ -46,7 +51,6 @@ export default function authorizeHandler(req, res) {
   const loginAction = hasExplicitVersion(req)
     ? `/${version}${flowSegment}/as/login`
     : `${flowSegment}/as/login`;
-  console.log("Looking for HTML at:", path.resolve("src/as/login-page.html"));
 
   if (!client_id || !redirect_uri) {
     return res.status(400).send("missing client_id or redirect_uri");
@@ -54,6 +58,20 @@ export default function authorizeHandler(req, res) {
 
   console.log("Serving login page for client_id:", client_id);
   console.log("Redirect URI:", redirect_uri);
+
+  // Bind the params to a server-side login transaction; the form carries only the opaque id.
+  const loginTxn = crypto.randomBytes(16).toString("hex");
+  loginTransactionStore.set(loginTxn, {
+    client_id,
+    redirect_uri,
+    state,
+    code_challenge,
+    code_challenge_method,
+    scope,
+    nonce,
+    expires_at: Date.now() + LOGIN_TXN_EXPIRES_IN * 1000,
+  });
+  setTimeout(() => loginTransactionStore.delete(loginTxn), LOGIN_TXN_EXPIRES_IN * 1000).unref();
 
   // Load template
   const template = fs.readFileSync(
@@ -63,14 +81,8 @@ export default function authorizeHandler(req, res) {
 
   // Replace placeholders
   const html = template
-    .replace("{{client_id}}", client_id)
-    .replace("{{redirect_uri}}", redirect_uri)
     .replace("{{form_action}}", loginAction)
-    .replace("{{state}}", state || "")
-    .replace("{{code_challenge}}", code_challenge || "")
-    .replace("{{code_challenge_method}}", code_challenge_method || "")
-    .replace("{{scope}}", scope || "")
-    .replace("{{nonce}}", nonce || "");
+    .replace("{{login_txn}}", loginTxn);
 
   res.set("Content-Type", "text/html");
   res.send(html);

--- a/mock-issuer-service/src/as/authorize.js
+++ b/mock-issuer-service/src/as/authorize.js
@@ -1,9 +1,46 @@
 import fs from "fs";
 import path from "path";
 import { hasExplicitVersion, resolveRequestVersion } from "../issuer-profile.js";
+import { parRequestStore } from "./authz-store.js";
 
 export default function authorizeHandler(req, res) {
-  const { client_id, redirect_uri, state } = req.query;
+  let {
+    client_id,
+    redirect_uri,
+    state,
+    code_challenge,
+    code_challenge_method,
+    scope,
+    nonce,
+  } = req.query;
+  const { request_uri } = req.query;
+
+  // PAR (RFC 9126): if a request_uri is supplied, resolve the pushed parameters
+  if (request_uri) {
+    console.log("Authorize via PAR — resolving request_uri:", request_uri);
+    const stored = parRequestStore.get(request_uri);
+    if (!stored) {
+      return res.status(400).send("invalid or unknown request_uri");
+    }
+    if (stored.expires_at < Date.now()) {
+      parRequestStore.delete(request_uri);
+      return res.status(400).send("request_uri has expired");
+    }
+    // client_id sent to the authorization endpoint must match the pushed one (RFC 9126 §4)
+    if (client_id && client_id !== stored.client_id) {
+      return res.status(400).send("client_id does not match the pushed authorization request");
+    }
+    client_id = stored.client_id;
+    redirect_uri = stored.redirect_uri;
+    state = stored.state;
+    code_challenge = stored.code_challenge;
+    code_challenge_method = stored.code_challenge_method;
+    scope = stored.scope;
+    nonce = stored.nonce;
+    // request_uri is single-use
+    parRequestStore.delete(request_uri);
+  }
+
   const version = resolveRequestVersion(req);
   const flowSegment = req.params?.flow === "pdi" ? "/pdi" : "";
   const loginAction = hasExplicitVersion(req)
@@ -29,7 +66,11 @@ export default function authorizeHandler(req, res) {
     .replace("{{client_id}}", client_id)
     .replace("{{redirect_uri}}", redirect_uri)
     .replace("{{form_action}}", loginAction)
-    .replace("{{state}}", state || "");
+    .replace("{{state}}", state || "")
+    .replace("{{code_challenge}}", code_challenge || "")
+    .replace("{{code_challenge_method}}", code_challenge_method || "")
+    .replace("{{scope}}", scope || "")
+    .replace("{{nonce}}", nonce || "");
 
   res.set("Content-Type", "text/html");
   res.send(html);

--- a/mock-issuer-service/src/as/authz-store.js
+++ b/mock-issuer-service/src/as/authz-store.js
@@ -3,6 +3,7 @@ import crypto from "crypto";
 export const authCodeStore = new Map();
 export const accessTokenStore = new Map();
 export const preAuthCodeStore = new Map();
+export const parRequestStore = new Map();
 
 export function generateAuthCode() {
   return crypto.randomBytes(16).toString("hex");

--- a/mock-issuer-service/src/as/authz-store.js
+++ b/mock-issuer-service/src/as/authz-store.js
@@ -4,6 +4,8 @@ export const authCodeStore = new Map();
 export const accessTokenStore = new Map();
 export const preAuthCodeStore = new Map();
 export const parRequestStore = new Map();
+// login_txn -> server-trusted authorization-request params (so the login form can't be tampered with)
+export const loginTransactionStore = new Map();
 
 export function generateAuthCode() {
   return crypto.randomBytes(16).toString("hex");

--- a/mock-issuer-service/src/as/login-page.html
+++ b/mock-issuer-service/src/as/login-page.html
@@ -28,13 +28,8 @@
       <p><strong>Password:</strong> any password (mock)</p>
 
       <form method="POST" action="{{form_action}}">
-        <input type="hidden" name="client_id" value="{{client_id}}" />
-        <input type="hidden" name="redirect_uri" value="{{redirect_uri}}" />
-        <input type="hidden" name="state" value="{{state}}" />
-        <input type="hidden" name="code_challenge" value="{{code_challenge}}" />
-        <input type="hidden" name="code_challenge_method" value="{{code_challenge_method}}" />
-        <input type="hidden" name="scope" value="{{scope}}" />
-        <input type="hidden" name="nonce" value="{{nonce}}" />
+        <!-- Only an opaque login-transaction id is sent; the AS holds the real params server-side. -->
+        <input type="hidden" name="login_txn" value="{{login_txn}}" />
 
         <button type="submit">Login & Continue</button>
       </form>

--- a/mock-issuer-service/src/as/login-page.html
+++ b/mock-issuer-service/src/as/login-page.html
@@ -31,6 +31,10 @@
         <input type="hidden" name="client_id" value="{{client_id}}" />
         <input type="hidden" name="redirect_uri" value="{{redirect_uri}}" />
         <input type="hidden" name="state" value="{{state}}" />
+        <input type="hidden" name="code_challenge" value="{{code_challenge}}" />
+        <input type="hidden" name="code_challenge_method" value="{{code_challenge_method}}" />
+        <input type="hidden" name="scope" value="{{scope}}" />
+        <input type="hidden" name="nonce" value="{{nonce}}" />
 
         <button type="submit">Login & Continue</button>
       </form>

--- a/mock-issuer-service/src/as/login.js
+++ b/mock-issuer-service/src/as/login.js
@@ -1,6 +1,17 @@
-import { generateAuthCode, authCodeStore } from "./authz-store.js";
+import { generateAuthCode, authCodeStore, loginTransactionStore } from "./authz-store.js";
 
 export default function loginHandler(req, res) {
+  const { login_txn } = req.body;
+
+  // Load the authorization-request params from server-side state, never from the
+  // browser body — the login form's hidden fields can be tampered with before POST.
+  const txn = loginTransactionStore.get(login_txn);
+  if (!txn || txn.expires_at < Date.now()) {
+    loginTransactionStore.delete(login_txn);
+    return res.status(400).send("invalid or expired login session");
+  }
+  loginTransactionStore.delete(login_txn); // single-use
+
   const {
     client_id,
     redirect_uri,
@@ -9,7 +20,7 @@ export default function loginHandler(req, res) {
     code_challenge_method,
     scope,
     nonce,
-  } = req.body;
+  } = txn;
 
   const code = generateAuthCode();
 

--- a/mock-issuer-service/src/as/login.js
+++ b/mock-issuer-service/src/as/login.js
@@ -1,7 +1,15 @@
 import { generateAuthCode, authCodeStore } from "./authz-store.js";
 
 export default function loginHandler(req, res) {
-  const { client_id, redirect_uri, state } = req.body;
+  const {
+    client_id,
+    redirect_uri,
+    state,
+    code_challenge,
+    code_challenge_method,
+    scope,
+    nonce,
+  } = req.body;
 
   const code = generateAuthCode();
 
@@ -9,6 +17,10 @@ export default function loginHandler(req, res) {
     client_id,
     redirect_uri,
     state,
+    code_challenge,
+    code_challenge_method,
+    scope,
+    nonce,
     created_at: Date.now()
   });
 

--- a/mock-issuer-service/src/as/metadata.js
+++ b/mock-issuer-service/src/as/metadata.js
@@ -1,5 +1,8 @@
 import { authServerBaseUrl, hasExplicitVersion, resolveRequestVersion } from "../issuer-profile.js";
 
+// Set MOCK_AS_PAR_ENABLED=false to advertise an AS without PAR (tests the fallback path).
+const PAR_ENABLED = (process.env.MOCK_AS_PAR_ENABLED ?? "true").toLowerCase() !== "false";
+
 export default function authServerMetadata(req, res) {
   const version = resolveRequestVersion(req);
   const flow = req.params?.flow === "pdi" ? "pdi" : null;
@@ -15,9 +18,6 @@ export default function authServerMetadata(req, res) {
     // Where the wallet will later exchange the code for tokens
     token_endpoint: `${asIssuer}/token`,
 
-    // Optional PAR (you can wire this later if you want)
-    // pushed_authorization_request_endpoint: `${AS_ISSUER}/par`,
-
     // For our simple IAR flow we just support the classic OAuth code flow
     response_types_supported: ["code"],
     grant_types_supported: ["authorization_code"],
@@ -28,13 +28,14 @@ export default function authServerMetadata(req, res) {
     // Nice to have: helps debuggers & wallet UIs
     scopes_supported: ["degree.read", "jwt_vc_json.read", "openid"],
     token_endpoint_auth_methods_supported: ["none"],
-
-    // For OpenID4VCI, authorization_details will be used
-    authorization_details_types_supported: ["openid_credential"]
   };
 
   if (flow === "pdi") {
     response.interactive_authorization_endpoint = `${asIssuer}/interactive-authorization`;
+  }
+
+  if (PAR_ENABLED) {
+    response.pushed_authorization_request_endpoint = `${asIssuer}/par`;
   }
 
   res.json(response);

--- a/mock-issuer-service/src/as/par.js
+++ b/mock-issuer-service/src/as/par.js
@@ -62,7 +62,11 @@ export default function parHandler(req, res) {
     expires_at: Date.now() + PAR_EXPIRES_IN * 1000
   });
 
-  console.log(`PAR issued request_uri: ${requestUri} (expires in ${PAR_EXPIRES_IN}s)`);
+  // request_uri is short-lived; evict it once it expires so the store does not grow unbounded.
+  setTimeout(() => parRequestStore.delete(requestUri), PAR_EXPIRES_IN * 1000).unref();
+
+  // Log only a short suffix — the full request_uri is a redeemable reference.
+  console.log(`PAR issued request_uri (…${requestUri.slice(-8)}, expires in ${PAR_EXPIRES_IN}s)`);
 
   // RFC 9126 §2.2 — success response is HTTP 201
   res.setHeader("Cache-Control", "no-store");

--- a/mock-issuer-service/src/as/par.js
+++ b/mock-issuer-service/src/as/par.js
@@ -1,0 +1,73 @@
+import crypto from "crypto";
+import { parRequestStore } from "./authz-store.js";
+
+// RFC 9126 — Pushed Authorization Requests
+const PAR_EXPIRES_IN = 90; // seconds
+
+export default function parHandler(req, res) {
+  const {
+    response_type,
+    client_id,
+    redirect_uri,
+    code_challenge,
+    code_challenge_method,
+    scope,
+    state,
+    nonce,
+    request_uri,
+  } = req.body;
+
+  console.log("PAR request received for client_id:", client_id);
+
+  // A PAR request MUST NOT itself contain a request_uri (RFC 9126 §2.1)
+  if (request_uri) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "request_uri is not allowed in a pushed authorization request"
+    });
+  }
+
+  if (!client_id) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "client_id is required"
+    });
+  }
+
+  if (!redirect_uri) {
+    return res.status(400).json({
+      error: "invalid_request",
+      error_description: "redirect_uri is required"
+    });
+  }
+
+  if (response_type && response_type !== "code") {
+    return res.status(400).json({
+      error: "unsupported_response_type",
+      error_description: "only response_type=code is supported"
+    });
+  }
+
+  const requestUri = `urn:ietf:params:oauth:request_uri:${crypto.randomBytes(16).toString("hex")}`;
+
+  parRequestStore.set(requestUri, {
+    response_type: response_type || "code",
+    client_id,
+    redirect_uri,
+    code_challenge,
+    code_challenge_method,
+    scope,
+    state,
+    nonce,
+    expires_at: Date.now() + PAR_EXPIRES_IN * 1000
+  });
+
+  console.log(`PAR issued request_uri: ${requestUri} (expires in ${PAR_EXPIRES_IN}s)`);
+
+  // RFC 9126 §2.2 — success response is HTTP 201
+  res.setHeader("Cache-Control", "no-store");
+  return res.status(201).json({
+    request_uri: requestUri,
+    expires_in: PAR_EXPIRES_IN
+  });
+}

--- a/mock-issuer-service/src/as/token.js
+++ b/mock-issuer-service/src/as/token.js
@@ -9,11 +9,10 @@ function base64url(str) {
 function verifyPkce(codeVerifier, codeChallenge, codeChallengeMethod) {
   if (!codeChallenge) return true; // PKCE was not used for this authorization
   if (!codeVerifier) return false;
-  if ((codeChallengeMethod || "S256") === "S256") {
-    const hash = crypto.createHash("sha256").update(codeVerifier).digest("base64");
-    return base64url(hash) === codeChallenge;
-  }
-  return codeVerifier === codeChallenge; // "plain"
+  // Only S256 is advertised in AS metadata (code_challenge_methods_supported); reject anything else.
+  if ((codeChallengeMethod || "S256") !== "S256") return false;
+  const hash = crypto.createHash("sha256").update(codeVerifier).digest("base64");
+  return base64url(hash) === codeChallenge;
 }
 
 export default function tokenHandler(req, res) {

--- a/mock-issuer-service/src/as/token.js
+++ b/mock-issuer-service/src/as/token.js
@@ -5,6 +5,17 @@ function base64url(str) {
   return str.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+// RFC 7636 — verify code_verifier against the code_challenge pushed at /par or /authorize
+function verifyPkce(codeVerifier, codeChallenge, codeChallengeMethod) {
+  if (!codeChallenge) return true; // PKCE was not used for this authorization
+  if (!codeVerifier) return false;
+  if ((codeChallengeMethod || "S256") === "S256") {
+    const hash = crypto.createHash("sha256").update(codeVerifier).digest("base64");
+    return base64url(hash) === codeChallenge;
+  }
+  return codeVerifier === codeChallenge; // "plain"
+}
+
 export default function tokenHandler(req, res) {
   const {
     grant_type,
@@ -12,7 +23,8 @@ export default function tokenHandler(req, res) {
     "pre-authorized_code": preAuthorizedCode,
     tx_code: txCodeInput,
     redirect_uri,
-    client_id
+    client_id,
+    code_verifier
   } = req.body;
   console.log("Token Request:", grant_type, code || preAuthorizedCode);
 
@@ -43,7 +55,15 @@ export default function tokenHandler(req, res) {
         error_description: "client_id mismatch"
       });
     }
-    
+
+    // 5. Validate PKCE (RFC 7636) against the code_challenge pushed at /par or /authorize
+    if (!verifyPkce(code_verifier, entry.code_challenge, entry.code_challenge_method)) {
+      return res.status(400).json({
+        error: "invalid_grant",
+        error_description: "code_verifier does not match the code_challenge"
+      });
+    }
+
     scope = entry.scope;
     authCodeStore.delete(code);
   } else if (grant_type === "urn:ietf:params:oauth:grant-type:pre-authorized_code") {

--- a/mock-issuer-service/src/credential/endpoint.js
+++ b/mock-issuer-service/src/credential/endpoint.js
@@ -26,6 +26,7 @@ const CONFIG_TO_FORMAT = {
 
 export default async function credentialEndpoint(req, res) {
   const body = req.body || {};
+  console.log("Credential request body:", JSON.stringify(body, null, 2));
   const explicitVersion = hasExplicitVersion(req);
   const version = resolveRequestVersion(req);
   const isV1 = explicitVersion
@@ -145,16 +146,20 @@ export default async function credentialEndpoint(req, res) {
   }
 
   if (isV1) {
-    return res.json({
+    const resp = {
       credentials: [ { credential } ],
       credential_issuer: issuerUrl,
-    });
+    };
+    console.log("Credential response (v1):", JSON.stringify(resp, null, 2));
+    return res.json(resp);
   }
 
-  return res.json({
+  const resp = {
     format,
     credential,
     c_nonce: "mock_nonce_123",
     c_nonce_expires_in: 86400,
-  });
+  };
+  console.log("Credential response:", JSON.stringify(resp, null, 2));
+  return res.json(resp);
 }

--- a/mock-issuer-service/src/credential/ldp-vc.js
+++ b/mock-issuer-service/src/credential/ldp-vc.js
@@ -305,13 +305,33 @@ async function signWithRsa(credential, issuerDid) {
   return signedVc;
 }
 
+class SafeEd25519Signature2018 extends Ed25519Signature2018 {
+  async canonize(input, { documentLoader, skipExpansion }) {
+    const { default: rdfCanonize } = await import('rdf-canonize');
+    const opts = {
+      algorithm: 'RDFC-1.0',
+      base: null,
+      documentLoader,
+      safe: false,
+      skipExpansion,
+      produceGeneralizedRdf: false,
+      rdfDirection: 'i18n-datatype',
+    };
+    const dataset = await jsonld.toRDF(input, opts);
+    return rdfCanonize.canonize(dataset, {
+      algorithm: 'RDFC-1.0',
+      format: 'application/n-quads',
+    });
+  }
+}
+
 async function signWithEd25519(credential, issuerDid) {
   const key = await Ed25519VerificationKey2018.generate({
     id: `${issuerDid}#key-0`,
     controller: issuerDid
   });
 
-  const suite = new Ed25519Signature2018({
+  const suite = new SafeEd25519Signature2018({
     key,
     date: new Date().toISOString()
   });

--- a/mock-issuer-service/src/issuer-profile.js
+++ b/mock-issuer-service/src/issuer-profile.js
@@ -1,4 +1,4 @@
-export const ISSUER = "https://704b-117-98-182-203.ngrok-free.app";
+export const ISSUER = "https://itzel-nonjournalistic-nonvicariously.ngrok-free.dev";
 
 export function normalizeSpecVersion(version) {
   return version === "draft13" ? "draft13" : "v1";

--- a/mock-issuer-service/src/server.js
+++ b/mock-issuer-service/src/server.js
@@ -7,6 +7,7 @@ import credentialOfferHandler from "./credential/offer.js";
 import issuerMetadata from "./issuer-metadata.js";
 import qrPageHandler, { qrImageHandler } from "./qr.js";
 import authorizeHandler from "./as/authorize.js";
+import parHandler from "./as/par.js";
 import interactiveAuthorizationHandler from "./as/interactive-authorization.js";
 import tokenHandler from "./as/token.js";
 import credentialHandler from "./credential/endpoint.js";
@@ -67,6 +68,26 @@ app.get("/credential-offer", credentialOfferHandler);
 
 // ---- AUTHORIZATION SERVER ---- //
 // app.get("/as/authorize", authorizeHandler);
+
+// ---- PUSHED AUTHORIZATION REQUEST (RFC 9126) ---- //
+app.post("/as/par", parHandler);
+app.post("/:flow(pdi)/as/par", parHandler);
+app.post("/:version(v1|draft13)/as/par", parHandler);
+app.post("/:version(v1|draft13)/:flow(pdi)/as/par", parHandler);
+
+// RFC 9126 §2.3 — non-POST requests to the PAR endpoint MUST get HTTP 405
+const parMethodNotAllowed = (req, res) => {
+  res.setHeader("Allow", "POST");
+  res.status(405).json({
+    error: "invalid_request",
+    error_description: "The pushed authorization request endpoint only supports POST"
+  });
+};
+app.all("/as/par", parMethodNotAllowed);
+app.all("/:flow(pdi)/as/par", parMethodNotAllowed);
+app.all("/:version(v1|draft13)/as/par", parMethodNotAllowed);
+app.all("/:version(v1|draft13)/:flow(pdi)/as/par", parMethodNotAllowed);
+
 app.post("/as/interactive-authorization", interactiveAuthorizationHandler);
 app.post("/:flow(pdi)/as/interactive-authorization", interactiveAuthorizationHandler);
 app.post("/:version(v1|draft13)/as/interactive-authorization", interactiveAuthorizationHandler);


### PR DESCRIPTION
Adds support for Pushed Authorization Requests (RFC 9126 / OID4VCI §5.1.4) to the mock Authorization Server, so the PAR flow can be tested end-to-end against `inji-vci-client`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pushed authorization requests, including a new endpoint and proper handling of request expiration.
  * Login and authorization flows now carry additional sign-in parameters such as PKCE values, requested scope, and nonce.
  * The authorization server metadata now advertises the new capability when enabled.

* **Bug Fixes**
  * Enforced matching client details and single-use request handling for pushed authorization requests.
  * Added PKCE verification during code exchange to reject mismatched or invalid verifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->