### PR TITLE
add: cnf support in sd-jwt | feat: control PDI VP request config in UI

### DIFF
--- a/mock-issuer-service/README.md
+++ b/mock-issuer-service/README.md
@@ -335,7 +335,7 @@ You can use `verifier-config.js` to control:
 
 * `specVersion`: selects whether the verifier request is built for `draft-23` or `version-1.0`
 * `responseMode`: controls how the verifier expects the presentation response
-* `clientIdScheme`: selects the verifier client ID scheme such as `did`, `redirect_uri`, or `pre-registered`
+* `clientIdPrefix`: selects the verifier client ID prefix such as `did` (draft-23), `decentralized_identifier` (version-1.0), `redirect_uri`, or `pre-registered`
 * `requestMode`: switches between `by_value` and `by_reference`
 * `verifierBaseUrl`: points the issuer to the verifier service instance to call
 * `signedRequest`: enables or disables signed verifier requests

--- a/mock-issuer-service/src/as/interactive-authorization.js
+++ b/mock-issuer-service/src/as/interactive-authorization.js
@@ -17,8 +17,8 @@ function randomCode() {
  * @returns {Promise<Object>} The VP request object
  */
 async function fetchVPRequest() {
-  const clientIdScheme = verifierConfig.clientIdScheme;
-  const draftVersion = verifierConfig.specVersion;
+  const clientIdPrefix = verifierConfig.clientIdPrefix;
+  const specVersion = verifierConfig.specVersion;
   const responseMode = verifierConfig.responseMode;
   const requestMode = verifierConfig.requestMode;
   const signedRequest = verifierConfig.signedRequest;
@@ -28,7 +28,7 @@ async function fetchVPRequest() {
     response_mode: responseMode,
   };
 
-  if (draftVersion === "version-1.0") {
+  if (specVersion === "version-1.0") {
     requestBody.dcql_query = verifierConfig.dcqlQuery;
   } else {
     requestBody.presentation_definition = verifierConfig.presentationDefinition;
@@ -36,9 +36,9 @@ async function fetchVPRequest() {
 
   try {
     const requestUrl = new URL(
-      `${verifierConfig.verifierBaseUrl}/verifier/${clientIdScheme}/${requestMode}`
+      `${verifierConfig.verifierBaseUrl}/verifier/${clientIdPrefix}/${requestMode}`
     );
-    requestUrl.searchParams.set("draft", draftVersion);
+    requestUrl.searchParams.set("spec", specVersion);
 
     console.log(
       `Fetching VP request info from: ${requestUrl.toString()}`

--- a/mock-issuer-service/src/as/interactive-authorization.js
+++ b/mock-issuer-service/src/as/interactive-authorization.js
@@ -153,9 +153,11 @@ export default async function interactiveAuthorizationHandler(req, res) {
     // Fetch the VP request object from the verifier service
     const requestObject = await fetchVPRequest();
 
+    const type = verifierConfig.responseMode.startsWith("iar") ? "openid4vp_presentation" : "urn:openid:dcp:iae:openid4vp_presentation"
+
     const interactionRequiredResponse = {
       status: "require_interaction",
-      type: "openid4vp_presentation",
+      type: type,
       auth_session: sessionId,
       credential_issuer: issuer,
       openid4vp_request: requestObject,

--- a/mock-issuer-service/src/as/verifier-config.js
+++ b/mock-issuer-service/src/as/verifier-config.js
@@ -1,6 +1,6 @@
 export const verifierConfig = {
   specVersion: "draft-23", // draft-23 or version-1.0
-  responseMode: "iar-post", // keep as iar-post or iar-post.jwt (encrypted response)
+  responseMode: "iar-post", // keep as iar-post / iae_post or iar-post.jwt / iae_post.jwt (encrypted response)
   clientIdPrefix: "did",
   requestMode: "by_reference", // by_value or by_reference
   verifierBaseUrl: "http://localhost:3000", // Verifier backend service URL

--- a/mock-issuer-service/src/as/verifier-config.js
+++ b/mock-issuer-service/src/as/verifier-config.js
@@ -1,7 +1,7 @@
 export const verifierConfig = {
   specVersion: "draft-23", // draft-23 or version-1.0
   responseMode: "iar-post", // keep as iar-post or iar-post.jwt (encrypted response)
-  clientIdScheme: "did", 
+  clientIdPrefix: "did",
   requestMode: "by_reference", // by_value or by_reference
   verifierBaseUrl: "http://localhost:3000", // Verifier backend service URL
   signedRequest: true, // Set to true if you want the request to be signed by the verifier or keep as false
@@ -35,7 +35,7 @@ export const verifierConfig = {
       {
         id: "id-card-query",
         format: "ldp_vc",
-        meta:{},
+        meta: {},
         claims: [
           {
             path: ["credentialSubject", "email"],

--- a/mock-issuer-service/src/credential/endpoint.js
+++ b/mock-issuer-service/src/credential/endpoint.js
@@ -13,12 +13,12 @@ import { createSdJwt } from "./sd-jwt.js";
 import { createMdoc } from "./mdoc.js";
 import { signLdpVc } from "./ldp-vc.js";
 
-const SUPPORTED_FORMATS = ["ldp_vc", "jwt_vc_json", "vc+sd-jwt", "mso_mdoc"];
+const SUPPORTED_FORMATS = ["ldp_vc", "jwt_vc_json", "vc+sd-jwt","dc+sd-jwt", "mso_mdoc"];
 
 // Minimal config-id → format map for the v1 flow where the client sends
 // credential_configuration_id instead of format.
 const CONFIG_TO_FORMAT = {
-  UniversityDegreeCredential: "ldp_vc",
+  FarmerCredential: "ldp_vc",
   JwtVerifiableCredential: "jwt_vc_json",
   SdJwtVerifiableCredential: "vc+sd-jwt",
   MdocVerifiableCredential: "mso_mdoc",
@@ -136,7 +136,7 @@ export default async function credentialEndpoint(req, res) {
             .setNotBefore('0s')
             .setExpirationTime('1y')
             .sign(privateKey);
-        } else if (format === "dc+sd-jwt" || format === "vc+sd-jwt") {
+        } else if (format === "vc+sd-jwt" || format === "dc+sd-jwt") {
           let holderCnfInfo = {};
           if (holderKey?.startsWith("did:jwk:")) {
             const encodedJwk = holderKey.slice("did:jwk:".length);

--- a/mock-issuer-service/src/credential/endpoint.js
+++ b/mock-issuer-service/src/credential/endpoint.js
@@ -149,7 +149,7 @@ export default async function credentialEndpoint(req, res) {
                 }
               }
             } catch (error) {
-              console.error("data in did:jwk not right")
+              console.error("data in did:jwk not right ",error)
               holderCnfInfo = {
                 "cnf": {
                   "kid": holderKey

--- a/mock-issuer-service/src/credential/endpoint.js
+++ b/mock-issuer-service/src/credential/endpoint.js
@@ -5,7 +5,7 @@ import {
   STATIC_MDL_MDOC,
   STATIC_MDL_MDOC_SAMPLE_B64URL,
 } from "./static-vc.js";
-import { SignJWT, generateKeyPair, exportJWK } from 'jose';
+import { SignJWT, generateKeyPair, exportJWK, decodeProtectedHeader } from 'jose';
 import { randomUUID, createHash } from 'node:crypto';
 import { ISSUER } from "../issuer-metadata.js";
 import { hasExplicitVersion, issuerBaseUrl, resolveRequestVersion } from "../issuer-profile.js";
@@ -85,6 +85,9 @@ export default async function credentialEndpoint(req, res) {
     proofJwt = body.proof.jwt;
   }
 
+  // Get the holder key from the proof JWT protected header "kid".
+  const holderKey = decodeProtectedHeader(proofJwt)?.kid;
+
   let credential;
 
   try {
@@ -133,8 +136,28 @@ export default async function credentialEndpoint(req, res) {
             .setNotBefore('0s')
             .setExpirationTime('1y')
             .sign(privateKey);
-        } else if (format === "vc+sd-jwt") {
-            credential = await createSdJwt(STATIC_SD_JWT_VC, privateKey, didJwk, didJwk);
+        } else if (format === "dc+sd-jwt" || format === "vc+sd-jwt") {
+          let holderCnfInfo = {};
+          if (holderKey?.startsWith("did:jwk:")) {
+            const encodedJwk = holderKey.slice("did:jwk:".length);
+            try {
+              const jwkString = Buffer.from(encodedJwk, "base64url").toString("utf8");
+              const parsedJwk = JSON.parse(jwkString);
+              holderCnfInfo = {
+                "cnf": {
+                  "jwk": parsedJwk
+                }
+              }
+            } catch (error) {
+              console.error("data in did:jwk not right")
+              holderCnfInfo = {
+                "cnf": {
+                  "kid": holderKey
+                }
+              }
+            }
+          }
+            credential = await createSdJwt({...STATIC_SD_JWT_VC, ...holderCnfInfo}, privateKey, didJwk, didJwk);
         } else if (format === "mso_mdoc") {
             credential = STATIC_MDL_MDOC_SAMPLE_B64URL;
         }

--- a/mock-issuer-service/src/credential/sd-jwt.js
+++ b/mock-issuer-service/src/credential/sd-jwt.js
@@ -13,17 +13,17 @@ export async function createSdJwt(payload, privateKey, issuer, holderDid) {
   const disclosures = [];
   const sdHashes = [];
 
-  const claimsToDisclose = Object.keys(payload).filter(k => k !== 'iss' && k !== 'sub' && k !== 'iat' && k !== 'exp' && k !== 'nbf' && k !== 'jti' && k !== 'vct');
+  const claimsToDisclose = Object.keys(payload).filter(k => k !== 'iss' && k !== 'sub' && k !== 'iat' && k !== 'exp' && k !== 'nbf' && k !== 'jti' && k !== 'vct' && k !== 'cnf');
 
   const newPayload = { ...payload };
-  
+
   for (const claim of claimsToDisclose) {
     const salt = base64url(randomBytes(16));
     const disclosureArray = [salt, claim, payload[claim]];
     const disclosureJson = JSON.stringify(disclosureArray);
     const disclosureB64 = Buffer.from(disclosureJson).toString('base64url');
     disclosures.push(disclosureB64);
-    
+
     const hash = base64url(sha256(disclosureB64));
     sdHashes.push(hash);
     delete newPayload[claim];

--- a/mock-issuer-service/src/issuance-options.js
+++ b/mock-issuer-service/src/issuance-options.js
@@ -2,6 +2,12 @@ const FLOW_OPTIONS = new Set(["normal", "pdi", "pre-auth", "pre-auth-tx"]);
 const VERSION_OPTIONS = new Set(["v1", "draft13"]);
 const CREDENTIAL_OPTIONS = new Set(["farmer", "employee", "sd-jwt", "mdoc"]);
 
+export const SPEC_VERSION_OPTIONS = new Set(["draft-23", "version-1.0"])
+export const RESPONSE_MODE_OPTIONS = new Set(["iar-post", "iar-post.jwt", "iae_post", "iae_post.jwt"]);
+export const CLIENT_ID_PREDIX_OPTIONS = new Set(["did", "redirect_uri", "pre-registered"])
+export const REQUEST_MODE_OPTIONS = new Set(["by_reference", "by_value"]);
+export const SIGNED_REQUEST_OPTIONS = new Set([true, false]);
+
 export const DEFAULT_ISSUANCE_OPTIONS = Object.freeze({
   flow: "normal",
   version: "v1",
@@ -10,7 +16,7 @@ export const DEFAULT_ISSUANCE_OPTIONS = Object.freeze({
 
 const CREDENTIAL_MAP = {
   farmer: {
-    configurationId: "UniversityDegreeCredential",
+    configurationId: "FarmerCredential",
     format: "ldp_vc",
     label: "Farmer Credential",
     scope: "degree.read",
@@ -47,12 +53,25 @@ export function resolveIssuanceOptions(query = {}) {
   const credential = CREDENTIAL_OPTIONS.has(query.credential)
     ? query.credential
     : DEFAULT_ISSUANCE_OPTIONS.credential;
+  const responseMode = RESPONSE_MODE_OPTIONS.has(query.responseMode)
+    ? query.responseMode
+    : "iar-post";
+  const clientIdScheme = CLIENT_ID_PREDIX_OPTIONS.has(query.clientIdScheme) ? query.clientIdScheme : "did"
+  const specVersion = SPEC_VERSION_OPTIONS.has(query.specVersion) ? query.specVersion : "draft-23"
+  const requestMode = REQUEST_MODE_OPTIONS.has(query.requestMode) ? query.requestMode : "by_reference"
+  const signedRequest = query.signedRequest ? query.signedRequest === "true" : true
+
 
   return {
     flow,
     version,
     credential,
     credentialDetails: CREDENTIAL_MAP[credential],
+    responseMode,
+    clientIdScheme,
+    specVersion,
+    requestMode,
+    signedRequest,
   };
 }
 

--- a/mock-issuer-service/src/issuance-options.js
+++ b/mock-issuer-service/src/issuance-options.js
@@ -4,7 +4,7 @@ const CREDENTIAL_OPTIONS = new Set(["farmer", "employee", "sd-jwt", "mdoc"]);
 
 export const SPEC_VERSION_OPTIONS = new Set(["draft-23", "version-1.0"])
 export const RESPONSE_MODE_OPTIONS = new Set(["iar-post", "iar-post.jwt", "iae_post", "iae_post.jwt"]);
-export const CLIENT_ID_PREDIX_OPTIONS = new Set(["did", "redirect_uri", "pre-registered"])
+export const CLIENT_ID_PREFIX_OPTIONS = new Set(["did", "decentralized_identifier", "redirect_uri", "pre-registered"])
 export const REQUEST_MODE_OPTIONS = new Set(["by_reference", "by_value"]);
 export const SIGNED_REQUEST_OPTIONS = new Set([true, false]);
 
@@ -56,7 +56,7 @@ export function resolveIssuanceOptions(query = {}) {
   const responseMode = RESPONSE_MODE_OPTIONS.has(query.responseMode)
     ? query.responseMode
     : "iar-post";
-  const clientIdScheme = CLIENT_ID_PREDIX_OPTIONS.has(query.clientIdScheme) ? query.clientIdScheme : "did"
+  const clientIdPrefix = CLIENT_ID_PREFIX_OPTIONS.has(query.clientIdPrefix) ? query.clientIdPrefix : "did"
   const specVersion = SPEC_VERSION_OPTIONS.has(query.specVersion) ? query.specVersion : "draft-23"
   const requestMode = REQUEST_MODE_OPTIONS.has(query.requestMode) ? query.requestMode : "by_reference"
   const signedRequest = query.signedRequest ? query.signedRequest === "true" : true
@@ -68,7 +68,7 @@ export function resolveIssuanceOptions(query = {}) {
     credential,
     credentialDetails: CREDENTIAL_MAP[credential],
     responseMode,
-    clientIdScheme,
+    clientIdPrefix,
     specVersion,
     requestMode,
     signedRequest,

--- a/mock-issuer-service/src/issuer-metadata.js
+++ b/mock-issuer-service/src/issuer-metadata.js
@@ -7,7 +7,7 @@ import {
 } from "./issuer-profile.js";
 
 const BASE_CREDENTIAL_CONFIGURATIONS = {
-  UniversityDegreeCredential: {
+  FarmerCredential: {
     format: "ldp_vc",
     scope: "degree.read",
     cryptographic_binding_methods_supported: ["jwk"],

--- a/mock-issuer-service/src/qr.js
+++ b/mock-issuer-service/src/qr.js
@@ -470,9 +470,9 @@ function renderPage(options, pin = null) {
                     "Response mode"
                   )}
                   ${dropDown(
-                    "clientIdScheme",
+                    "clientIdPrefix",
                     updateClientIdPrefixes(options.specVersion),
-                    options.clientIdScheme,
+                    options.clientIdPrefix,
                     "VP request Client ID Scheme"
                   )}
                   ${dropDown(

--- a/mock-issuer-service/src/qr.js
+++ b/mock-issuer-service/src/qr.js
@@ -1,6 +1,7 @@
 import QRCode from "qrcode";
 import { ISSUER } from "./issuer-metadata.js";
-import { buildOfferUrl, resolveIssuanceOptions } from "./issuance-options.js";
+import { buildOfferUrl, resolveIssuanceOptions, RESPONSE_MODE_OPTIONS, SPEC_VERSION_OPTIONS, CLIENT_ID_PREDIX_OPTIONS, REQUEST_MODE_OPTIONS, SIGNED_REQUEST_OPTIONS } from "./issuance-options.js";
+import { verifierConfig } from "./as/verifier-config.js";
 
 function escapeHtml(value) {
   return String(value)
@@ -36,6 +37,30 @@ function optionButton(name, value, currentValue, label, hint) {
       <span>${escapeHtml(label)}</span>
       <small>${escapeHtml(hint)}</small>
     </label>
+  `;
+}
+
+const responseModes = Array.from(RESPONSE_MODE_OPTIONS).map(name => ({ name }))
+const specVersionOptions = Array.from(SPEC_VERSION_OPTIONS).map(name => ({ name }))
+const clientIdSchemeOptions = Array.from(CLIENT_ID_PREDIX_OPTIONS).map(name => ({ name }))
+const requestModeOptions = Array.from(REQUEST_MODE_OPTIONS).map(name => ({ name }))
+const signedRequestOptions = Array.from(SIGNED_REQUEST_OPTIONS).map(val => ({ name: String(val) }))
+
+function dropDown(name, options, currentValue, hint = "Option") {
+  return `
+    <div class="select-field">
+      <small>${hint}</small>
+      <select name="${name}" id="${name}">
+        ${options.map(option => `
+          <option
+            value="${option.name}"
+            ${option.name === currentValue ? "selected" : ""}
+          >
+            ${option.name}
+          </option>
+        `).join("")}
+      </select>
+    </div>
   `;
 }
 
@@ -336,6 +361,53 @@ function renderPage(options, pin = null) {
           grid-template-columns: 1fr;
         }
       }
+
+      .dropdown-group {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 20px;
+      }
+
+      .select-field {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .select-field label {
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--text);
+      }
+
+      .select-field small {
+        color: var(--text-muted);
+        font-size: 13px;
+        line-height: 1.4;
+      }
+
+      .select-field select {
+        width: 100%;
+        padding: 10px 14px;
+        font: inherit;
+        color: var(--text);
+        background: var(--surface-muted);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        outline: none;
+        transition: border-color .2s, box-shadow .2s, background .2s;
+        cursor: pointer;
+      }
+
+      .select-field select:hover {
+        border-color: var(--accent);
+      }
+
+      .select-field select:focus {
+        border-color: var(--accent);
+        background: #fff;
+        box-shadow: 0 0 0 3px rgba(23, 107, 82, 0.15);
+      }
     </style>
   </head>
   <body>
@@ -371,6 +443,45 @@ function renderPage(options, pin = null) {
                 ${optionButton("flow", "pdi", options.flow, "PDI", "Presentation during issuance")}
               </div>
             </div>
+
+            ${options.flow === "pdi" ? `
+              <div class="control-group">
+                <h2>OpenID4VP Request Config</h2>
+                <div class="dropdown-group">
+                  ${dropDown(
+                    "specVersion",
+                    specVersionOptions,
+                    options.specVersion,
+                    "VP request spec version"
+                  )}
+                  ${dropDown(
+                    "responseMode",
+                    responseModes,
+                    options.responseMode,
+                    "Response mode"
+                  )}
+                  ${dropDown(
+                    "clientIdScheme",
+                    clientIdSchemeOptions,
+                    options.clientIdScheme,
+                    "VP request Client ID Scheme"
+                  )}
+                  ${dropDown(
+                    "requestMode",
+                    requestModeOptions,
+                    options.requestMode,
+                    "VP Request Mode"
+                  )}
+                  ${dropDown(
+                    "signedRequest",
+                    signedRequestOptions,
+                    options.signedRequest ? "true" : "false",
+                    "Should the VP request be signed?"
+                  )}
+                </div>
+              </div>
+            `
+            : ""}
 
             <div class="control-group">
               <h2>Spec version</h2>
@@ -460,6 +571,14 @@ export async function qrImageHandler(req, res) {
 export default async function qrPageHandler(req, res) {
   const options = resolveIssuanceOptions(req.query);
   let pin = req.query.tx_code;
+
+  if (options.flow === "pdi") {
+    verifierConfig.specVersion = options.specVersion;
+    verifierConfig.responseMode = options.responseMode;
+    verifierConfig.clientIdScheme = options.clientIdScheme;
+    verifierConfig.requestMode = options.requestMode;
+    verifierConfig.signedRequest = options.signedRequest;
+  }
 
   if (options.flow === "pre-auth-tx" && !pin) {
     pin = Math.floor(1000 + Math.random() * 9000).toString();

--- a/mock-issuer-service/src/qr.js
+++ b/mock-issuer-service/src/qr.js
@@ -1,6 +1,6 @@
 import QRCode from "qrcode";
 import { ISSUER } from "./issuer-metadata.js";
-import { buildOfferUrl, resolveIssuanceOptions, RESPONSE_MODE_OPTIONS, SPEC_VERSION_OPTIONS, CLIENT_ID_PREDIX_OPTIONS, REQUEST_MODE_OPTIONS, SIGNED_REQUEST_OPTIONS } from "./issuance-options.js";
+import { buildOfferUrl, resolveIssuanceOptions, RESPONSE_MODE_OPTIONS, SPEC_VERSION_OPTIONS, CLIENT_ID_PREFIX_OPTIONS, REQUEST_MODE_OPTIONS, SIGNED_REQUEST_OPTIONS } from "./issuance-options.js";
 import { verifierConfig } from "./as/verifier-config.js";
 
 function escapeHtml(value) {
@@ -40,9 +40,18 @@ function optionButton(name, value, currentValue, label, hint) {
   `;
 }
 
+function updateClientIdPrefixes(specVersion) {
+  let data
+  if(specVersion === "version-1.0") {
+    data = [...CLIENT_ID_PREFIX_OPTIONS].filter(data => data!="did")
+  } else {
+    data = [...CLIENT_ID_PREFIX_OPTIONS].filter(data => data!="decentralized_identifier")
+  }
+  return Array.from(data).map(name => ({ name }))
+}
+
 const responseModes = Array.from(RESPONSE_MODE_OPTIONS).map(name => ({ name }))
 const specVersionOptions = Array.from(SPEC_VERSION_OPTIONS).map(name => ({ name }))
-const clientIdSchemeOptions = Array.from(CLIENT_ID_PREDIX_OPTIONS).map(name => ({ name }))
 const requestModeOptions = Array.from(REQUEST_MODE_OPTIONS).map(name => ({ name }))
 const signedRequestOptions = Array.from(SIGNED_REQUEST_OPTIONS).map(val => ({ name: String(val) }))
 
@@ -462,7 +471,7 @@ function renderPage(options, pin = null) {
                   )}
                   ${dropDown(
                     "clientIdScheme",
-                    clientIdSchemeOptions,
+                    updateClientIdPrefixes(options.specVersion),
                     options.clientIdScheme,
                     "VP request Client ID Scheme"
                   )}
@@ -575,7 +584,7 @@ export default async function qrPageHandler(req, res) {
   if (options.flow === "pdi") {
     verifierConfig.specVersion = options.specVersion;
     verifierConfig.responseMode = options.responseMode;
-    verifierConfig.clientIdScheme = options.clientIdScheme;
+    verifierConfig.clientIdPrefix = options.clientIdPrefix;
     verifierConfig.requestMode = options.requestMode;
     verifierConfig.signedRequest = options.signedRequest;
   }

--- a/openid4vp-service/README.md
+++ b/openid4vp-service/README.md
@@ -75,9 +75,9 @@ To simplify the process, script is also exposed
 |-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | OpenID4VP specification versions                          | `draft-23`, `version-1.0`                                                                                                                                                                                                                                                                                                                                         |
 | Device flow                                               | cross device flow (QR code generated for the authorization request), Same device flow (Generated QR code with authorization request is clickable)                                                                                                                                                                                                                  |
-| Client id scheme                                          | `pre-registered`, `redirect_uri`, `did`                                                                                                                                                                                                                                                                                                                            |
+| Client id Prefix                                          | `pre-registered`, `redirect_uri`, `decentralized_identifier (or did for OVP draft 23)`                                                                                                                                                                                                                                                                                                                            |
 | Signed authorization request algorithms                   | Ed25519                                                                                                                                                                                                                                                                                                                                                            |
-| Creating authorization request                            | By value, By reference ( via `request_uri` method) <br> _[Note: Authorization request by value is not supported for the did client ID scheme, as it requires a signed request. Instead, a Request URI should be used to fetch the signed authorization request ([reference](https://openid.net/specs/openid-4-verifiable-presentations-1_0-23.html#section-3.2))]_ |
+| Creating authorization request                            | By value, By reference ( via `request_uri` method) <br> _[Note: Authorization request by value is not supported for the decentralized_identifier Client id Prefix (or did client ID scheme), as it requires a signed request. Instead, a Request URI should be used to fetch the signed authorization request ([reference](https://openid.net/specs/openid-4-verifiable-presentations-1_0-23.html#section-3.2))]_ |
 | Creating presentation definition in authorization request | By value, By reference (via `presentation_definition_uri`)                                                                                                                                                                                                                                                                                                         |
 | Authorization Response mode                               | `direct_post`, `direct_post.jwt` (with encrypted & unsigned responses)                                                                                                                                                                                                                                                                                             |
 | Authorization Response type                               | `vp_token`                                                                                                                                                                                                                                                                                                                                                         |
@@ -91,11 +91,11 @@ To simplify the process, script is also exposed
 - Example usage: Fetch the JWKS from `<base-url>/.well-known/jwks.json` to validate the Verifier's JWTs.
 
 
-## Client id schemes supported
+## Client id Prefixes / Schemes supported
 
-1. `redirect_uri` scheme (example: client_id: `https://client.example.org/cb`)
-2. `did` scheme (example: client_id: `did:example:123`)
-3. `pre-registered` scheme (example: client_id: `mock-example client`)
+1. `redirect_uri` (example: client_id: `https://client.example.org/cb`)
+2. `decentralized_identifier` (example: client_id: `decentralized_identifier:did:example:123`) OR `did` scheme (example: client_id: `did:example:123`)
+3. `pre-registered` (example: client_id: `mock-example client`)
 
 ## Port & Tunnel Configuration
 
@@ -121,8 +121,8 @@ To simplify the process, script is also exposed
 | Method | Path | Responsibility |
 |--------|------|----------------|
 | `GET` | `/.well-known/jwks.json` | Exposes verifier public keys as a JWKS for signature verification. |
-| `GET`, `POST` | `/verifier/:client_id_scheme/:request_mode` | Generates the authorization request and returns the QR response payload. Applies request overrides such as `dcql_query`, `presentation_definition`, signing option, draft/version, and response mode. |
-| `GET`, `POST` | `/verifier/get-auth-request-obj/:sessionId/:client_id_scheme` | Returns the actual authorization request object for `by_reference` flows using the request data stored for the given `sessionId`. |
+| `GET`, `POST` | `/verifier/:client_id_prefix/:request_mode` | Generates the authorization request and returns the QR response payload. Applies request overrides such as `dcql_query`, `presentation_definition`, signing option, draft/version, and response mode. |
+| `GET`, `POST` | `/verifier/get-auth-request-obj/:sessionId/:client_id_prefix` | Returns the actual authorization request object for `by_reference` flows using the request data stored for the given `sessionId`. |
 | `GET` | `/verifier/presentation-definition-uri/:sessionId` | Returns the session-scoped presentation definition, including any stored overrides for that `sessionId`. |
 | `GET` | `/verifier/presentation_definition_uri` | Legacy endpoint that returns the default presentation definition without session-specific overrides. |
 | `POST` | `/verifier/vp-response` | Accepts the wallet VP response and stores it as the latest received verifier result. |
@@ -136,7 +136,7 @@ To simplify the process, script is also exposed
 Generate a QR code payload for a `by_reference` request:
 
 ```bash
-curl -X POST "http://localhost:3000/verifier/pre-registered/by_reference?draft=version-1.0" \
+curl -X POST "http://localhost:3000/verifier/pre-registered/by_reference?spec=version-1.0" \
   -H "Content-Type: application/json" \
   -d '{
     "signed": true,
@@ -150,7 +150,7 @@ curl -X POST "http://localhost:3000/verifier/pre-registered/by_reference?draft=v
 Fetch the actual authorization request object for a session:
 
 ```bash
-curl "http://localhost:3000/verifier/get-auth-request-obj/<sessionId>/pre-registered?draft=version-1.0&response_mode=direct_post"
+curl "http://localhost:3000/verifier/get-auth-request-obj/<sessionId>/pre-registered?spec=version-1.0&response_mode=direct_post"
 ```
 
 Post a wallet VP response back to the verifier:
@@ -168,9 +168,9 @@ curl -X POST "http://localhost:3000/verifier/vp-response" \
 
 ## Session Creation Using sessionId
 
-- When `/verifier/:client_id_scheme/:request_mode` is called, the service generates a new `sessionId` for that request.
+- When `/verifier/:client_id_prefix/:request_mode` is called, the service generates a new `sessionId` for that request.
 - The generated `sessionId` is used to store session-scoped request data such as `dcql_query` and `presentation_definition` overrides.
-- For `by_reference` flows, the `sessionId` is embedded into the generated `request_uri` as `/verifier/get-auth-request-obj/:sessionId/:client_id_scheme`.
+- For `by_reference` flows, the `sessionId` is embedded into the generated `request_uri` as `/verifier/get-auth-request-obj/:sessionId/:client_id_prefix`.
 - When presentation definition is served by reference, the service also uses the same `sessionId` in `/verifier/presentation-definition-uri/:sessionId`.
 - This allows each QR code request to resolve the correct request object and presentation definition without mixing overrides from other sessions.
 

--- a/openid4vp-service/VerifierMetadata.js
+++ b/openid4vp-service/VerifierMetadata.js
@@ -84,7 +84,7 @@ const VerifierMetadata = {
 function getVerifierMetadata(responseMode, version) {
   let metadata = JSON.parse(JSON.stringify(VerifierMetadata[version] || {}));
 
-  if (responseMode === ResponseModes.DIRECT_POST) {
+  if (!String(responseMode).includes(".jwt")) {
     if (version === DRAFT_VERSIONS.V_1_0) {
       delete metadata["encrypted_response_enc_values_supported"];
     }

--- a/openid4vp-service/VerifierMetadata.js
+++ b/openid4vp-service/VerifierMetadata.js
@@ -1,5 +1,5 @@
 const clientMetadata = require('./clientMetadataMock.json');
-const {DRAFT_VERSIONS, ResponseModes} = require("./constants");
+const {SPEC_VERSIONS, ResponseModes} = require("./constants");
 const { defaultVerifierKeys } = require('./encryptionKeyManagement');
 
 // Convert base64 to base64url format (just character replacement, no re-encoding)
@@ -85,10 +85,10 @@ function getVerifierMetadata(responseMode, version) {
   let metadata = JSON.parse(JSON.stringify(VerifierMetadata[version] || {}));
 
   if (!String(responseMode).includes(".jwt")) {
-    if (version === DRAFT_VERSIONS.V_1_0) {
+    if (version === SPEC_VERSIONS.V_1_0) {
       delete metadata["encrypted_response_enc_values_supported"];
     }
-    if (version === DRAFT_VERSIONS.DRAFT_23) {
+    if (version === SPEC_VERSIONS.DRAFT_23) {
       delete metadata["authorization_encrypted_response_enc"];
       delete metadata["authorization_encrypted_response_alg"];
     }

--- a/openid4vp-service/app.js
+++ b/openid4vp-service/app.js
@@ -88,7 +88,7 @@ app.post('/verifier/vp-response', (req, res) => {
 
     const response = {
         redirect_uri: `${baseUrl}/verifier/callback#response_code=${responseCode}`,
-        message: `Verifiable presentation is not right`,
+        message: `Verifiable presentation is all right`,
     };
     console.log("Response to be sent:", response);
     res.status(200).json(response);

--- a/openid4vp-service/constants.js
+++ b/openid4vp-service/constants.js
@@ -34,7 +34,7 @@ const ContentTypes = {
 const CLIENT_ID_PREFIXES = {
     PRE_REGISTERED: "pre-registered",
     REDIRECT_URI: "redirect_uri",
-    DECENTRALIZED_IDENTIFIER: "decentralized identifier"
+    DECENTRALIZED_IDENTIFIER: "decentralized_identifier"
 }
 
 // enum for Spec versions

--- a/openid4vp-service/constants.js
+++ b/openid4vp-service/constants.js
@@ -30,15 +30,15 @@ const ContentTypes = {
 };
 
 
-// enum for client_id_schemes
-const CLIENT_ID_SCHEMES = {
+// enum for client_id_prefixes
+const CLIENT_ID_PREFIXES = {
     PRE_REGISTERED: "pre-registered",
     REDIRECT_URI: "redirect_uri",
-    DID: "did"
+    DECENTRALIZED_IDENTIFIER: "decentralized identifier"
 }
 
-// enum for draft versions
-const DRAFT_VERSIONS = {
+// enum for Spec versions
+const SPEC_VERSIONS = {
     DRAFT_21: "draft-21",
     DRAFT_23: "draft-23",
     V_1_0: "version-1.0"
@@ -78,7 +78,7 @@ module.exports = {
 
     REQUEST_MODES,
     ResponseModes,
-    CLIENT_ID_SCHEMES,
-    DRAFT_VERSIONS,
+    CLIENT_ID_PREFIXES,
+    SPEC_VERSIONS,
     REQUEST_SIGNING_SUPPORT_MODES
 };

--- a/openid4vp-service/inputData.js
+++ b/openid4vp-service/inputData.js
@@ -1,13 +1,13 @@
-const { CLIENT_ID_SCHEMES } = require("./constants");
+const { CLIENT_ID_PREFIXES } = require("./constants");
 const preRegistered = require("./requestData/preRegistered");
 const redirectUri = require("./requestData/redirectUri");
 const did = require("./requestData/did");
 
 // Final map of all combinations
 const finalAuthRequestMap = {
-    [CLIENT_ID_SCHEMES.PRE_REGISTERED]: preRegistered.map,
-    [CLIENT_ID_SCHEMES.REDIRECT_URI]: redirectUri.map,
-    [CLIENT_ID_SCHEMES.DID]: did.map,
+    [CLIENT_ID_PREFIXES.PRE_REGISTERED]: preRegistered.map,
+    [CLIENT_ID_PREFIXES.REDIRECT_URI]: redirectUri.map,
+    [CLIENT_ID_PREFIXES.DECENTRALIZED_IDENTIFIER]: did.map,
 }
 
 module.exports = {

--- a/openid4vp-service/ovp-client/src/components/qr/PresentationRequestModal.jsx
+++ b/openid4vp-service/ovp-client/src/components/qr/PresentationRequestModal.jsx
@@ -15,14 +15,14 @@ export default function PresentationRequestModal({
     onDcqlQueryChange,
     draftPresentationDefinitionValue,
     onPresentationDefinitionChange,
-    selectedSpecIsV10,
+    selectedSpecIsV1_0,
     allowInvalidRequest,
     onAllowInvalidRequestChange,
 }) {
     const [showInstructions, setShowInstructions] = useState(false);
 
-    const isV10 = selectedSpecIsV10;
-    const title = isV10 
+    const isV1_0 = selectedSpecIsV1_0;
+    const title = isV1_0 
         ? "Presentation Request Details (DCQL Query)" 
         : "Presentation Request Details (Presentation Definition)";
 
@@ -37,7 +37,7 @@ export default function PresentationRequestModal({
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
                 <h3 style={{ margin: 0 }}>{title}</h3>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    {isV10 && (
+                    {isV1_0 && (
                         <button
                             onClick={() => setShowInstructions(true)}
                             aria-label={"Open DCQL instructions"}
@@ -63,7 +63,7 @@ export default function PresentationRequestModal({
                 </div>
             </div>
 
-            {isV10 ? (
+            {isV1_0 ? (
                 <DcqlQueryEditor
                     value={draftDcqlQueryValue}
                     disabled={false}
@@ -91,7 +91,7 @@ export default function PresentationRequestModal({
                 </Button>
             </div>
 
-            {isV10 && (
+            {isV1_0 && (
                 <DcqlInstructionsModal
                     isOpen={showInstructions}
                     onClose={() => setShowInstructions(false)}
@@ -109,7 +109,7 @@ PresentationRequestModal.propTypes = {
     onDcqlQueryChange: PropTypes.func.isRequired,
     draftPresentationDefinitionValue: PropTypes.object,
     onPresentationDefinitionChange: PropTypes.func.isRequired,
-    selectedSpecIsV10: PropTypes.bool.isRequired,
+    selectedSpecIsV1_0: PropTypes.bool.isRequired,
     allowInvalidRequest: PropTypes.bool,
     onAllowInvalidRequestChange: PropTypes.func,
 };

--- a/openid4vp-service/ovp-client/src/components/qr/PresentationRequestModal.jsx
+++ b/openid4vp-service/ovp-client/src/components/qr/PresentationRequestModal.jsx
@@ -15,13 +15,13 @@ export default function PresentationRequestModal({
     onDcqlQueryChange,
     draftPresentationDefinitionValue,
     onPresentationDefinitionChange,
-    selectedDraftIsV10,
+    selectedSpecIsV10,
     allowInvalidRequest,
     onAllowInvalidRequestChange,
 }) {
     const [showInstructions, setShowInstructions] = useState(false);
 
-    const isV10 = selectedDraftIsV10;
+    const isV10 = selectedSpecIsV10;
     const title = isV10 
         ? "Presentation Request Details (DCQL Query)" 
         : "Presentation Request Details (Presentation Definition)";
@@ -109,7 +109,7 @@ PresentationRequestModal.propTypes = {
     onDcqlQueryChange: PropTypes.func.isRequired,
     draftPresentationDefinitionValue: PropTypes.object,
     onPresentationDefinitionChange: PropTypes.func.isRequired,
-    selectedDraftIsV10: PropTypes.bool.isRequired,
+    selectedSpecIsV10: PropTypes.bool.isRequired,
     allowInvalidRequest: PropTypes.bool,
     onAllowInvalidRequestChange: PropTypes.func,
 };

--- a/openid4vp-service/ovp-client/src/components/qr/QrControls.jsx
+++ b/openid4vp-service/ovp-client/src/components/qr/QrControls.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Dropdown from '../common/Dropdown';
 import Toggle from '../common/Toggle';
 import Button from '../common/Button';
-import {REQUEST_MODES, RESPONSE_MODES, DRAFT_VERSIONS} from '../../constants/constants';
+import {REQUEST_MODES, RESPONSE_MODES, SPEC_VERSIONS} from '../../constants/constants';
 import {Palette, font, spacing, cardStyles} from '../../styles/palette';
 
 const fieldLabelStyle = {
@@ -17,11 +17,11 @@ const fieldLabelStyle = {
 export default function QrControls({
     isByValue,
     isByReference,
-    selectedDraft,
+    selectedSpec,
     selectedResponseMode,
     isRequestSigned,
     onRequestModeChange,
-    onDraftVersionChange,
+    onSpecVersionChange,
     onResponseModeChange,
     onSignedChange,
     onOpenPresentationDetails,
@@ -33,10 +33,10 @@ export default function QrControls({
         {name: 'By Reference', selected: isByReference, onChange: () => onRequestModeChange(REQUEST_MODES.BY_REFERENCE)},
     ];
 
-    const draftOptions = Object.values(DRAFT_VERSIONS).map((v) => ({
+    const specOptions = Object.values(SPEC_VERSIONS).map((v) => ({
         name: v,
-        selected: selectedDraft === v,
-        onChange: () => onDraftVersionChange(v),
+        selected: selectedSpec === v,
+        onChange: () => onSpecVersionChange(v),
     }));
 
     const responseModeOptions = Object.values(RESPONSE_MODES).map((m) => ({
@@ -85,7 +85,7 @@ export default function QrControls({
                     }}>
                         <div>
                             <label style={fieldLabelStyle}>OpenID4VP Spec Version</label>
-                            <Dropdown options={draftOptions} fullWidth/>
+                            <Dropdown options={specOptions} fullWidth/>
                         </div>
                         <div>
                             <label style={fieldLabelStyle}>Response Mode</label>
@@ -150,11 +150,11 @@ export default function QrControls({
 QrControls.propTypes = {
     isByValue: PropTypes.bool.isRequired,
     isByReference: PropTypes.bool.isRequired,
-    selectedDraft: PropTypes.string.isRequired,
+    selectedSpec: PropTypes.string.isRequired,
     selectedResponseMode: PropTypes.string.isRequired,
     isRequestSigned: PropTypes.bool.isRequired,
     onRequestModeChange: PropTypes.func.isRequired,
-    onDraftVersionChange: PropTypes.func.isRequired,
+    onSpecVersionChange: PropTypes.func.isRequired,
     onResponseModeChange: PropTypes.func.isRequired,
     onSignedChange: PropTypes.func.isRequired,
     onOpenPresentationDetails: PropTypes.func.isRequired,

--- a/openid4vp-service/ovp-client/src/constants/constants.js
+++ b/openid4vp-service/ovp-client/src/constants/constants.js
@@ -1,12 +1,12 @@
-// enum for client_id_schemes
-export const CLIENT_ID_SCHEMES = {
+// enum for CLIENT_ID_PREFIXES
+export const CLIENT_ID_PREFIXES = {
     PRE_REGISTERED: "pre-registered",
     REDIRECT_URI: "redirect_uri",
     DID: "did"
 }
 
-// enum for draft versions
-export const DRAFT_VERSIONS = {
+// enum for spec versions
+export const SPEC_VERSIONS = {
     V_1_0: "version-1.0",
     DRAFT_23: "draft-23",
     // DRAFT_21: "draft-21",

--- a/openid4vp-service/ovp-client/src/hooks/usePresentationRequest.js
+++ b/openid4vp-service/ovp-client/src/hooks/usePresentationRequest.js
@@ -35,10 +35,10 @@ const emptyPreset = DCQL_PRESETS.find((preset) => preset.value === 'empty');
 /**
  * Manages DCQL / presentation-definition state and the presentation request modal.
  *
- * @param {boolean}  selectedDraftIsV10 - whether spec V1.0 is active
+ * @param {boolean}  selectedSpecIsV10 - whether spec V1.0 is active
  * @param {function} onFetch            - (dcqlQueryOverride, presentationDefinitionOverride) => Promise
  */
-export const usePresentationRequest = ({selectedDraftIsV10, onFetch}) => {
+export const usePresentationRequest = ({selectedSpecIsV10, onFetch}) => {
     const [showPresentationRequestDetails, setShowPresentationRequestDetails] = useState(false);
     const [dcqlQueryValue, setDcqlQueryValue] = useState(cloneQuery(emptyPreset?.query || EMPTY_QUERY));
     const [draftDcqlQueryValue, setDraftDcqlQueryValue] = useState(cloneQuery(emptyPreset?.query || EMPTY_QUERY));
@@ -61,12 +61,12 @@ export const usePresentationRequest = ({selectedDraftIsV10, onFetch}) => {
     };
 
     const getDcqlQueryOverride = () => {
-        if (!selectedDraftIsV10 || !hasSubmittedDcqlQuery) return undefined;
+        if (!selectedSpecIsV10 || !hasSubmittedDcqlQuery) return undefined;
         return normalizeDcqlForSubmission(dcqlQueryValue, allowInvalidDcqlRequest);
     };
 
     const getPresentationDefinitionOverride = () => {
-        if (selectedDraftIsV10 || !hasSubmittedPresentationDefinition) return undefined;
+        if (selectedSpecIsV10 || !hasSubmittedPresentationDefinition) return undefined;
         return presentationDefinitionValue && typeof presentationDefinitionValue === 'object'
             ? presentationDefinitionValue
             : {};
@@ -77,7 +77,7 @@ export const usePresentationRequest = ({selectedDraftIsV10, onFetch}) => {
     const handlePresentationDefinitionChange = (value) => setDraftPresentationDefinitionValue(value);
 
     const openPresentationRequestDetails = () => {
-        if (selectedDraftIsV10) {
+        if (selectedSpecIsV10) {
             setDraftDcqlQueryValue(cloneQuery(dcqlQueryValue));
         } else {
             setDraftPresentationDefinitionValue(JSON.parse(JSON.stringify(presentationDefinitionValue)));
@@ -92,12 +92,12 @@ export const usePresentationRequest = ({selectedDraftIsV10, onFetch}) => {
     };
 
     const submitPresentationRequestDetails = async () => {
-        const dcqlQueryOverride = selectedDraftIsV10
+        const dcqlQueryOverride = selectedSpecIsV10
             ? normalizeDcqlForSubmission(draftDcqlQueryValue, allowInvalidDcqlRequest)
             : undefined;
-        const presentationDefinitionOverride = !selectedDraftIsV10 ? draftPresentationDefinitionValue : undefined;
+        const presentationDefinitionOverride = !selectedSpecIsV10 ? draftPresentationDefinitionValue : undefined;
 
-        if (selectedDraftIsV10) {
+        if (selectedSpecIsV10) {
             setDcqlQueryValue(cloneQuery(dcqlQueryOverride));
             setHasSubmittedDcqlQuery(true);
         } else {

--- a/openid4vp-service/ovp-client/src/hooks/usePresentationRequest.js
+++ b/openid4vp-service/ovp-client/src/hooks/usePresentationRequest.js
@@ -35,10 +35,10 @@ const emptyPreset = DCQL_PRESETS.find((preset) => preset.value === 'empty');
 /**
  * Manages DCQL / presentation-definition state and the presentation request modal.
  *
- * @param {boolean}  selectedSpecIsV10 - whether spec V1.0 is active
+ * @param {boolean}  selectedSpecIsV1_0 - whether spec V1.0 is active
  * @param {function} onFetch            - (dcqlQueryOverride, presentationDefinitionOverride) => Promise
  */
-export const usePresentationRequest = ({selectedSpecIsV10, onFetch}) => {
+export const usePresentationRequest = ({selectedSpecIsV1_0, onFetch}) => {
     const [showPresentationRequestDetails, setShowPresentationRequestDetails] = useState(false);
     const [dcqlQueryValue, setDcqlQueryValue] = useState(cloneQuery(emptyPreset?.query || EMPTY_QUERY));
     const [draftDcqlQueryValue, setDraftDcqlQueryValue] = useState(cloneQuery(emptyPreset?.query || EMPTY_QUERY));
@@ -61,12 +61,12 @@ export const usePresentationRequest = ({selectedSpecIsV10, onFetch}) => {
     };
 
     const getDcqlQueryOverride = () => {
-        if (!selectedSpecIsV10 || !hasSubmittedDcqlQuery) return undefined;
+        if (!selectedSpecIsV1_0 || !hasSubmittedDcqlQuery) return undefined;
         return normalizeDcqlForSubmission(dcqlQueryValue, allowInvalidDcqlRequest);
     };
 
     const getPresentationDefinitionOverride = () => {
-        if (selectedSpecIsV10 || !hasSubmittedPresentationDefinition) return undefined;
+        if (selectedSpecIsV1_0 || !hasSubmittedPresentationDefinition) return undefined;
         return presentationDefinitionValue && typeof presentationDefinitionValue === 'object'
             ? presentationDefinitionValue
             : {};
@@ -77,7 +77,7 @@ export const usePresentationRequest = ({selectedSpecIsV10, onFetch}) => {
     const handlePresentationDefinitionChange = (value) => setDraftPresentationDefinitionValue(value);
 
     const openPresentationRequestDetails = () => {
-        if (selectedSpecIsV10) {
+        if (selectedSpecIsV1_0) {
             setDraftDcqlQueryValue(cloneQuery(dcqlQueryValue));
         } else {
             setDraftPresentationDefinitionValue(JSON.parse(JSON.stringify(presentationDefinitionValue)));
@@ -92,12 +92,12 @@ export const usePresentationRequest = ({selectedSpecIsV10, onFetch}) => {
     };
 
     const submitPresentationRequestDetails = async () => {
-        const dcqlQueryOverride = selectedSpecIsV10
+        const dcqlQueryOverride = selectedSpecIsV1_0
             ? normalizeDcqlForSubmission(draftDcqlQueryValue, allowInvalidDcqlRequest)
             : undefined;
-        const presentationDefinitionOverride = !selectedSpecIsV10 ? draftPresentationDefinitionValue : undefined;
+        const presentationDefinitionOverride = !selectedSpecIsV1_0 ? draftPresentationDefinitionValue : undefined;
 
-        if (selectedSpecIsV10) {
+        if (selectedSpecIsV1_0) {
             setDcqlQueryValue(cloneQuery(dcqlQueryOverride));
             setHasSubmittedDcqlQuery(true);
         } else {

--- a/openid4vp-service/ovp-client/src/hooks/usePresentationRequest.js
+++ b/openid4vp-service/ovp-client/src/hooks/usePresentationRequest.js
@@ -1,5 +1,4 @@
 import {useState} from 'react';
-import {DRAFT_VERSIONS} from '../constants/constants';
 import {DCQL_PRESETS} from '../constants/dcql-presets';
 import {cloneQuery, ensureDcqlShape} from '../utility/dcqlHelper';
 
@@ -36,7 +35,7 @@ const emptyPreset = DCQL_PRESETS.find((preset) => preset.value === 'empty');
 /**
  * Manages DCQL / presentation-definition state and the presentation request modal.
  *
- * @param {boolean}  selectedDraftIsV10 - whether draft V1.0 is active
+ * @param {boolean}  selectedDraftIsV10 - whether spec V1.0 is active
  * @param {function} onFetch            - (dcqlQueryOverride, presentationDefinitionOverride) => Promise
  */
 export const usePresentationRequest = ({selectedDraftIsV10, onFetch}) => {

--- a/openid4vp-service/ovp-client/src/hooks/useQrFetch.js
+++ b/openid4vp-service/ovp-client/src/hooks/useQrFetch.js
@@ -19,7 +19,7 @@ export const useQrFetch = () => {
     }, []);
 
     const fetchQrCodeData = useCallback(async (
-        clientIdScheme,
+        clientIdPrefix,
         requestMode,
         draftVersion,
         isRequestSigned = false,
@@ -41,9 +41,9 @@ export const useQrFetch = () => {
                 qrRequestBody.presentation_definition = presentationDefinitionOverride;
             }
 
-            // draft is intentionally kept as query param for backend compatibility
+            // spec is intentionally kept as query param for backend compatibility
             const qrResponse = await axios.post(
-                `${BACKEND_URL}/verifier/${clientIdScheme}/${requestMode}?draft=${draftVersion}`,
+                `${BACKEND_URL}/verifier/${clientIdPrefix}/${requestMode}?spec=${draftVersion}`,
                 qrRequestBody,
                 {headers: {'ngrok-skip-browser-warning': 'true'}},
             );

--- a/openid4vp-service/ovp-client/src/hooks/useQrFetch.js
+++ b/openid4vp-service/ovp-client/src/hooks/useQrFetch.js
@@ -21,7 +21,7 @@ export const useQrFetch = () => {
     const fetchQrCodeData = useCallback(async (
         clientIdPrefix,
         requestMode,
-        draftVersion,
+        specVersion,
         isRequestSigned = false,
         responseMode = 'direct_post',
         dcqlQueryOverride,
@@ -43,7 +43,7 @@ export const useQrFetch = () => {
 
             // spec is intentionally kept as query param for backend compatibility
             const qrResponse = await axios.post(
-                `${BACKEND_URL}/verifier/${clientIdPrefix}/${requestMode}?spec=${draftVersion}`,
+                `${BACKEND_URL}/verifier/${clientIdPrefix}/${requestMode}?spec=${specVersion}`,
                 qrRequestBody,
                 {headers: {'ngrok-skip-browser-warning': 'true'}},
             );

--- a/openid4vp-service/ovp-client/src/screen/Home.js
+++ b/openid4vp-service/ovp-client/src/screen/Home.js
@@ -1,6 +1,6 @@
 import React, {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
-import {CLIENT_ID_SCHEMES, DRAFT_VERSIONS} from "../constants/constants";
+import {CLIENT_ID_PREFIXES, SPEC_VERSIONS} from "../constants/constants";
 import {INJIWEB_URL} from "../constants/mockui-constants";
 import Button from "../components/common/Button";
 import {backgroundStyle, Palette, font} from "../styles/palette";
@@ -71,18 +71,18 @@ const Home = () => {
     }, []);
 
     const endpoints = [
-        {name: CLIENT_ID_SCHEMES.PRE_REGISTERED},
-        {name: CLIENT_ID_SCHEMES.REDIRECT_URI},
-        {name: CLIENT_ID_SCHEMES.DID}
+        {name: CLIENT_ID_PREFIXES.PRE_REGISTERED},
+        {name: CLIENT_ID_PREFIXES.REDIRECT_URI},
+        {name: CLIENT_ID_PREFIXES.DID}
     ];
 
-    const handleClientIdSchemeClick = (endpointObj) => {
-        // Default  Draft 23
+    const handleClientIdPrefixClick = (endpointObj) => {
+        // Default  V1
         navigate('/qr', {
             state: {
                 name: endpointObj.name,
-                draftVersion: DRAFT_VERSIONS.DRAFT_23,
-                title: `${endpointObj.name} - ${DRAFT_VERSIONS.DRAFT_23}`
+                draftVersion: SPEC_VERSIONS.V_1_0,
+                title: `${endpointObj.name} - ${SPEC_VERSIONS.DRAFT_23}`
             }
         });
     };
@@ -117,20 +117,20 @@ const Home = () => {
                 </p>
             </div>
             <div>
-                <p>Please select a Client Id Scheme to generate an Authorization Request QR code:</p>
+                <p>Please select a Client ID Prefix / Client ID Scheme to generate an Authorization Request QR code:</p>
                 <div style={styles.buttonGrid}>
                     {endpoints.map(e => (
                         <div key={e.name} style={{ display: 'flex', alignItems: 'baseline'}}>
                             <span role="img" aria-label="emoji" style={styles.emoji}>
-                                {e.name === CLIENT_ID_SCHEMES.PRE_REGISTERED ? '🔐' :
-                                    e.name === CLIENT_ID_SCHEMES.REDIRECT_URI ? '🔄' : '🆔'}
+                                {e.name === CLIENT_ID_PREFIXES.PRE_REGISTERED ? '🔐' :
+                                    e.name === CLIENT_ID_PREFIXES.REDIRECT_URI ? '🔄' : '🆔'}
                             </span>
                             <Button
-                                onClick={() => handleClientIdSchemeClick(e)}
+                                onClick={() => handleClientIdPrefixClick(e)}
                                 variant={"secondary"}
                                 style={styles.button}
                             >
-                                {e.name}
+                                {e.name === CLIENT_ID_PREFIXES.DID ? "Decentralized Identifier / Did" : e.name}
                             </Button>
                         </div>
                     ))}

--- a/openid4vp-service/ovp-client/src/screen/Home.js
+++ b/openid4vp-service/ovp-client/src/screen/Home.js
@@ -81,8 +81,8 @@ const Home = () => {
         navigate('/qr', {
             state: {
                 name: endpointObj.name,
-                draftVersion: SPEC_VERSIONS.V_1_0,
-                title: `${endpointObj.name} - ${SPEC_VERSIONS.DRAFT_23}`
+                specVersion: SPEC_VERSIONS.V_1_0,
+                title: `${endpointObj.name} - ${SPEC_VERSIONS.V_1_0}`
             }
         });
     };

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -3,7 +3,7 @@ import {useLocation, useNavigate} from 'react-router-dom';
 import {INJIWEB_URL} from '../constants/mockui-constants';
 import {Loader} from '../components/common/Loader';
 import {Palette, font, spacing} from '../styles/palette';
-import {DRAFT_VERSIONS, REQUEST_MODES, RESPONSE_MODES} from '../constants/constants';
+import {SPEC_VERSIONS, REQUEST_MODES, RESPONSE_MODES} from '../constants/constants';
 import {ScanResult} from '../components/scan/ScanResult';
 import Error from '../components/common/Error';
 import QrScreenHeader from '../components/qr/QrScreenHeader';
@@ -63,11 +63,25 @@ const QrScreen = () => {
 
     const [isByValue, setIsByValue] = useState(true);
     const [isByReference, setIsByReference] = useState(false);
-    const [selectedDraft, setSelectedDraft] = useState(Object.values(DRAFT_VERSIONS)[0]);
+    const [selectedSpec, setSelectedSpec] = useState(Object.values(SPEC_VERSIONS)[0]);
     const [selectedResponseMode, setSelectedResponseMode] = useState(Object.values(RESPONSE_MODES)[0]);
     const [isRequestSigned, setIsRequestSigned] = useState(false);
 
-    const selectedDraftIsV10 = selectedDraft === DRAFT_VERSIONS.V_1_0;
+    const selectedSpecIsV10 = selectedSpec === SPEC_VERSIONS.V_1_0;
+
+    // Determine client_id_prefix based on spec version if prefix is 'did', otherwise keep the provided prefix
+    const getClientIdPrefix = (clientIdPrefix, spec) => {
+        if (clientIdPrefix === 'did') {
+            // If prefix is 'did', determine based on spec version
+            if (spec === SPEC_VERSIONS.V_1_0) {
+                return 'decentralized_identifier';
+            } else {
+                return 'did';
+            } 
+        }
+        // Otherwise, keep the provided prefix as-is
+        return clientIdPrefix;
+    };
 
     const {
         qrData, qrSize, qrCodeData, inputData, actualAuthorizationRequestObject, errorMessage,
@@ -76,24 +90,24 @@ const QrScreen = () => {
 
     const doFetch = useCallback((dcqlQueryOverride, presentationDefinitionOverride) =>
         fetchQrCodeData(
-            state.name,
+            getClientIdPrefix(state.name, selectedSpec),
             isByValue ? REQUEST_MODES.BY_VALUE : REQUEST_MODES.BY_REFERENCE,
-            selectedDraft,
+            selectedSpec,
             isRequestSigned,
             selectedResponseMode,
             dcqlQueryOverride,
             presentationDefinitionOverride,
         ),
-    [fetchQrCodeData, state, isByValue, selectedDraft, isRequestSigned, selectedResponseMode]);
+    [fetchQrCodeData, state, isByValue, selectedSpec, isRequestSigned, selectedResponseMode]);
 
-    const presentationRequest = usePresentationRequest({selectedDraftIsV10, onFetch: doFetch});
+    const presentationRequest = usePresentationRequest({selectedSpecIsV10: selectedSpecIsV10, onFetch: doFetch});
 
     useEffect(() => {
         const dcqlQueryOverride = presentationRequest.getDcqlQueryOverride();
         const presentationDefinitionOverride = presentationRequest.getPresentationDefinitionOverride();
         if (dcqlQueryOverride === null) return;
         void doFetch(dcqlQueryOverride, presentationDefinitionOverride);
-    }, [state, isByValue, isByReference, selectedDraft, fetchQrCodeData, isRequestSigned, selectedResponseMode]);
+    }, [state, isByValue, isByReference, selectedSpec, fetchQrCodeData, isRequestSigned, selectedResponseMode]);
 
     useEffect(() => {
         document.title = 'Scan';
@@ -113,18 +127,18 @@ const QrScreen = () => {
         resetValues();
         const dcqlQueryOverride = presentationRequest.getDcqlQueryOverride();
         if (dcqlQueryOverride === null) return;
-        await fetchQrCodeData(state.name, mode, selectedDraft, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
+        await fetchQrCodeData(getClientIdPrefix(state.name, selectedSpec), mode, selectedSpec, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
     };
 
-    const handleDraftVersionChange = async (version) => {
-        if (version === selectedDraft) return;
-        setSelectedDraft(version);
+    const handleSpecVersionChange = async (version) => {
+        if (version === selectedSpec) return;
+        setSelectedSpec(version);
         resetValues();
-        const dcqlQueryOverride = (version === DRAFT_VERSIONS.V_1_0 && presentationRequest.hasSubmittedDcqlQuery)
+        const dcqlQueryOverride = (version === SPEC_VERSIONS.V_1_0 && presentationRequest.hasSubmittedDcqlQuery)
             ? presentationRequest.getDcqlQueryOverride()
             : undefined;
         if (dcqlQueryOverride === null) return;
-        await fetchQrCodeData(state.name, isByValue ? REQUEST_MODES.BY_VALUE : REQUEST_MODES.BY_REFERENCE, version, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
+        await fetchQrCodeData(getClientIdPrefix(state.name, version), isByValue ? REQUEST_MODES.BY_VALUE : REQUEST_MODES.BY_REFERENCE, version, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
     };
 
     const handleResponseModeChange = (mode) => {
@@ -138,18 +152,18 @@ const QrScreen = () => {
         window.open(`${INJIWEB_URL}?${strippedRequest}`, '_blank');
     };
 
-    const subtitle = `${state?.name || 'QR Code Image'} · ${selectedDraft}`;
+    const subtitle = `${getClientIdPrefix(state?.name, selectedSpec) || 'QR Code Image'} · ${selectedSpec}`;
     const styles = getPageStyles();
 
     const controls = (
         <QrControls
             isByValue={isByValue}
             isByReference={isByReference}
-            selectedDraft={selectedDraft}
+            selectedSpec={selectedSpec}
             selectedResponseMode={selectedResponseMode}
             isRequestSigned={isRequestSigned}
             onRequestModeChange={handleRequestModeChange}
-            onDraftVersionChange={handleDraftVersionChange}
+            onSpecVersionChange={handleSpecVersionChange}
             onResponseModeChange={handleResponseModeChange}
             onSignedChange={(isChecked) => setIsRequestSigned(isChecked)}
             onOpenPresentationDetails={presentationRequest.openPresentationRequestDetails}
@@ -165,7 +179,7 @@ const QrScreen = () => {
             onDcqlQueryChange={presentationRequest.handleDcqlQueryChange}
             draftPresentationDefinitionValue={presentationRequest.draftPresentationDefinitionValue}
             onPresentationDefinitionChange={presentationRequest.handlePresentationDefinitionChange}
-            selectedDraftIsV10={selectedDraftIsV10}
+            selectedSpecIsV10={selectedSpecIsV10}
             allowInvalidRequest={presentationRequest.allowInvalidDcqlRequest}
             onAllowInvalidRequestChange={presentationRequest.setAllowInvalidDcqlRequest}
         />

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -67,11 +67,11 @@ const QrScreen = () => {
     const [selectedResponseMode, setSelectedResponseMode] = useState(Object.values(RESPONSE_MODES)[0]);
     const [isRequestSigned, setIsRequestSigned] = useState(false);
 
-    const selectedSpecIsV10 = selectedSpec === SPEC_VERSIONS.V_1_0;
+    const selectedSpecIsV1_0 = selectedSpec === SPEC_VERSIONS.V_1_0;
 
     // Determine client_id_prefix based on spec version if prefix is 'did', otherwise keep the provided prefix
     const getClientIdPrefix = (clientIdPrefix, spec) => {
-        if (clientIdPrefix === 'did') {
+        if (clientIdPrefix === 'did' || clientIdPrefix === 'decentralized_identifier') {
             // If prefix is 'did', determine based on spec version
             if (spec === SPEC_VERSIONS.V_1_0) {
                 return 'decentralized_identifier';
@@ -100,7 +100,7 @@ const QrScreen = () => {
         ),
     [fetchQrCodeData, state, isByValue, selectedSpec, isRequestSigned, selectedResponseMode]);
 
-    const presentationRequest = usePresentationRequest({selectedSpecIsV10: selectedSpecIsV10, onFetch: doFetch});
+    const presentationRequest = usePresentationRequest({selectedSpecIsV1_0: selectedSpecIsV1_0, onFetch: doFetch});
 
     useEffect(() => {
         const dcqlQueryOverride = presentationRequest.getDcqlQueryOverride();
@@ -179,7 +179,7 @@ const QrScreen = () => {
             onDcqlQueryChange={presentationRequest.handleDcqlQueryChange}
             draftPresentationDefinitionValue={presentationRequest.draftPresentationDefinitionValue}
             onPresentationDefinitionChange={presentationRequest.handlePresentationDefinitionChange}
-            selectedSpecIsV10={selectedSpecIsV10}
+            selectedSpecIsV1_0={selectedSpecIsV1_0}
             allowInvalidRequest={presentationRequest.allowInvalidDcqlRequest}
             onAllowInvalidRequestChange={presentationRequest.setAllowInvalidDcqlRequest}
         />

--- a/openid4vp-service/ovp-client/src/screen/QrScreen.js
+++ b/openid4vp-service/ovp-client/src/screen/QrScreen.js
@@ -90,7 +90,7 @@ const QrScreen = () => {
 
     const doFetch = useCallback((dcqlQueryOverride, presentationDefinitionOverride) =>
         fetchQrCodeData(
-            getClientIdPrefix(state.name, selectedSpec),
+            getClientIdPrefix(state?.name, selectedSpec),
             isByValue ? REQUEST_MODES.BY_VALUE : REQUEST_MODES.BY_REFERENCE,
             selectedSpec,
             isRequestSigned,
@@ -127,7 +127,7 @@ const QrScreen = () => {
         resetValues();
         const dcqlQueryOverride = presentationRequest.getDcqlQueryOverride();
         if (dcqlQueryOverride === null) return;
-        await fetchQrCodeData(getClientIdPrefix(state.name, selectedSpec), mode, selectedSpec, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
+        await fetchQrCodeData(getClientIdPrefix(state?.name, selectedSpec), mode, selectedSpec, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
     };
 
     const handleSpecVersionChange = async (version) => {
@@ -138,7 +138,7 @@ const QrScreen = () => {
             ? presentationRequest.getDcqlQueryOverride()
             : undefined;
         if (dcqlQueryOverride === null) return;
-        await fetchQrCodeData(getClientIdPrefix(state.name, version), isByValue ? REQUEST_MODES.BY_VALUE : REQUEST_MODES.BY_REFERENCE, version, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
+        await fetchQrCodeData(getClientIdPrefix(state?.name, version), isByValue ? REQUEST_MODES.BY_VALUE : REQUEST_MODES.BY_REFERENCE, version, isRequestSigned, selectedResponseMode, dcqlQueryOverride);
     };
 
     const handleResponseModeChange = (mode) => {

--- a/openid4vp-service/presentation-request/presentationDefinitionMock.json
+++ b/openid4vp-service/presentation-request/presentationDefinitionMock.json
@@ -1,29 +1,71 @@
 {
-    "id": "c4822b58-7fb4-454e-b827-f8758fe27f9a",
-    "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
-    "input_descriptors": [
-      {
-        "id": "Mock Identity card credential",
-        "format": {
-          "vc+sd-jwt": {
-            "sd-jwt_alg_values": [
-              "ES256"
-            ]
-          }
-        },
-        "constraints": {
-          "fields": [
-            {
-              "path": [
-                "$.vct"
-              ],
-              "filter": {
-                "type": "string",
-                "pattern": "MockVerifiableCredential_SD_JWT"
-              }
-            }
+  "id": "c4822b58-7fb4-454e-b827-f8758fe27f9a",
+  "purpose": "Relying party is requesting your digital ID for the purpose of Self-Authentication",
+  "input_descriptors": [
+    {
+      "id": "Mock Identity card credential",
+      "format": {
+        "vc+sd-jwt": {
+          "sd-jwt_alg_values": [
+            "ES256"
           ]
         }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.vct"
+            ],
+            "filter": {
+              "type": "string",
+              "pattern": "MockVerifiableCredential_SD_JWT"
+            }
+          }
+        ]
       }
-    ]
-  }
+    },
+    {
+      "id": "id card credential",
+      "format": {
+        "ldp_vc": {
+          "proof_type": [
+            "Ed25519Signature2020"
+          ]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$.credentialSubject.email"
+            ],
+            "filter": {
+              "type": "string",
+              "pattern": "@gmail.com"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "org.iso.18013.5.1.mDL",
+      "format": {
+        "mso_mdoc": {
+          "alg": [
+            "ES256"
+          ]
+        }
+      },
+      "constraints": {
+        "fields": [
+          {
+            "path": [
+              "$['org.iso.18013.5.1']['document_number']"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/openid4vp-service/requestData/did.js
+++ b/openid4vp-service/requestData/did.js
@@ -1,5 +1,5 @@
 const {
-  nonce, state, responseUri, baseUrl, presentationDefinitionUri, didDocumentUrl,REQUEST_MODES, DRAFT_VERSIONS, REQUEST_SIGNING_SUPPORT_MODES, ResponseModes
+  nonce, state, responseUri, baseUrl, presentationDefinitionUri, didDocumentUrl,REQUEST_MODES, SPEC_VERSIONS, REQUEST_SIGNING_SUPPORT_MODES, ResponseModes
 } = require("../constants");
 const clientMetadata = require('../clientMetadataMock.json');
 const {getVerifierMetadata} = require("../VerifierMetadata");
@@ -15,7 +15,7 @@ const didAuthorizationRequestVersion1 = {
   "nonce": nonce,
   "state": state,
   "response_uri": responseUri,
-  "client_metadata": getVerifierMetadata(ResponseModes.DIRECT_POST, DRAFT_VERSIONS.V_1_0),
+  "client_metadata": getVerifierMetadata(ResponseModes.DIRECT_POST, SPEC_VERSIONS.V_1_0),
 }
 
 const didAuthorizationRequestDraft23 = {
@@ -44,7 +44,7 @@ const didAuthorizationRequestDraft21 = {
 
 const didAuthorizationRequestParamsVersion1 = {
   "client_id": `decentralized_identifier:${didDocumentUrl}`,
-  "request_uri": `${baseUrl}/verifier/get-auth-request-obj/did?draft=version-1.0`,
+  "request_uri": `${baseUrl}/verifier/get-auth-request-obj/did?spec=version-1.0`,
   "request_uri_method": "post"
 }
 
@@ -63,14 +63,14 @@ const map = {
   [REQUEST_SIGNING_SUPPORT_MODES.SIGNED_REQUEST_SUPPORTED]: true,
   [REQUEST_SIGNING_SUPPORT_MODES.UNSIGNED_REQUEST_SUPPORTED]: false,
   [REQUEST_MODES.BY_REFERENCE]: {
-    [DRAFT_VERSIONS.V_1_0]: didAuthorizationRequestParamsVersion1,
-    [DRAFT_VERSIONS.DRAFT_23]: didAuthorizationRequestParamsDraft23,
-    [DRAFT_VERSIONS.DRAFT_21]: didAuthorizationRequestParamsDraft21,
+    [SPEC_VERSIONS.V_1_0]: didAuthorizationRequestParamsVersion1,
+    [SPEC_VERSIONS.DRAFT_23]: didAuthorizationRequestParamsDraft23,
+    [SPEC_VERSIONS.DRAFT_21]: didAuthorizationRequestParamsDraft21,
   },
   [REQUEST_MODES.BY_VALUE]: {
-    [DRAFT_VERSIONS.V_1_0]: didAuthorizationRequestVersion1,
-    [DRAFT_VERSIONS.DRAFT_23]: didAuthorizationRequestDraft23,
-    [DRAFT_VERSIONS.DRAFT_21]: didAuthorizationRequestDraft21,
+    [SPEC_VERSIONS.V_1_0]: didAuthorizationRequestVersion1,
+    [SPEC_VERSIONS.DRAFT_23]: didAuthorizationRequestDraft23,
+    [SPEC_VERSIONS.DRAFT_21]: didAuthorizationRequestDraft21,
   },
 };
 

--- a/openid4vp-service/requestData/preRegistered.js
+++ b/openid4vp-service/requestData/preRegistered.js
@@ -1,6 +1,6 @@
 const {
     nonce, state, responseUri, baseUrl, presentationDefinitionUri,
-    CLIENT_ID_SCHEMES, REQUEST_MODES, DRAFT_VERSIONS, REQUEST_SIGNING_SUPPORT_MODES, ResponseModes
+    CLIENT_ID_PREFIXES, REQUEST_MODES, SPEC_VERSIONS, REQUEST_SIGNING_SUPPORT_MODES, ResponseModes
 } = require("../constants");
 const clientMetadata = require('../clientMetadataMock.json');
 const {getVerifierMetadata} = require("../VerifierMetadata");
@@ -16,7 +16,7 @@ const preRegisteredAuthorizationRequestVersion1 = {
     "nonce": nonce,
     "state": state,
     "response_uri": responseUri,
-    "client_metadata": JSON.stringify(getVerifierMetadata(ResponseModes.DIRECT_POST_JWT, DRAFT_VERSIONS.V_1_0)),
+    "client_metadata": JSON.stringify(getVerifierMetadata(ResponseModes.DIRECT_POST_JWT, SPEC_VERSIONS.V_1_0)),
 }
 
 const preRegisteredAuthorizationRequestDraft23 = {
@@ -57,14 +57,14 @@ const map = {
     [REQUEST_SIGNING_SUPPORT_MODES.SIGNED_REQUEST_SUPPORTED] : true,
     [REQUEST_SIGNING_SUPPORT_MODES.UNSIGNED_REQUEST_SUPPORTED] : true,
     [REQUEST_MODES.BY_REFERENCE]: {
-        [DRAFT_VERSIONS.V_1_0]: preRegisteredAuthorizationRequestParamsDraft23,
-        [DRAFT_VERSIONS.DRAFT_23]: preRegisteredAuthorizationRequestParamsDraft23,
-        [DRAFT_VERSIONS.DRAFT_21]: preRegisteredAuthorizationRequestParamsDraft21,
+        [SPEC_VERSIONS.V_1_0]: preRegisteredAuthorizationRequestParamsDraft23,
+        [SPEC_VERSIONS.DRAFT_23]: preRegisteredAuthorizationRequestParamsDraft23,
+        [SPEC_VERSIONS.DRAFT_21]: preRegisteredAuthorizationRequestParamsDraft21,
     },
     [REQUEST_MODES.BY_VALUE]: {
-        [DRAFT_VERSIONS.V_1_0]: preRegisteredAuthorizationRequestVersion1,
-        [DRAFT_VERSIONS.DRAFT_23]: preRegisteredAuthorizationRequestDraft23,
-        [DRAFT_VERSIONS.DRAFT_21]: preRegisteredAuthorizationRequestDraft21,
+        [SPEC_VERSIONS.V_1_0]: preRegisteredAuthorizationRequestVersion1,
+        [SPEC_VERSIONS.DRAFT_23]: preRegisteredAuthorizationRequestDraft23,
+        [SPEC_VERSIONS.DRAFT_21]: preRegisteredAuthorizationRequestDraft21,
     }
 };
 

--- a/openid4vp-service/requestData/redirectUri.js
+++ b/openid4vp-service/requestData/redirectUri.js
@@ -1,5 +1,5 @@
 const {
-    nonce, state, responseUri, baseUrl, presentationDefinitionUri,REQUEST_MODES, DRAFT_VERSIONS, REQUEST_SIGNING_SUPPORT_MODES, ResponseModes
+    nonce, state, responseUri, baseUrl, presentationDefinitionUri,REQUEST_MODES, SPEC_VERSIONS, REQUEST_SIGNING_SUPPORT_MODES, ResponseModes
 } = require("../constants");
 const clientMetadata = require('../clientMetadataMock.json');
 const {getVerifierMetadata} = require("../VerifierMetadata");
@@ -15,7 +15,7 @@ const redirectAuthorizationRequestVersion1 = {
     "nonce": nonce,
     "state": state,
     "response_uri": responseUri,
-    "client_metadata": JSON.stringify(getVerifierMetadata(ResponseModes.DIRECT_POST, DRAFT_VERSIONS.V_1_0)),
+    "client_metadata": JSON.stringify(getVerifierMetadata(ResponseModes.DIRECT_POST, SPEC_VERSIONS.V_1_0)),
 }
 
 const redirectAuthorizationRequestDraft23 = {
@@ -56,14 +56,14 @@ const map = {
     [REQUEST_SIGNING_SUPPORT_MODES.SIGNED_REQUEST_SUPPORTED] : false,
     [REQUEST_SIGNING_SUPPORT_MODES.UNSIGNED_REQUEST_SUPPORTED] : true,
     [REQUEST_MODES.BY_REFERENCE]: {
-        [DRAFT_VERSIONS.V_1_0]: redirectUriAuthorizationRequestParamsDraft23,
-        [DRAFT_VERSIONS.DRAFT_23]: redirectUriAuthorizationRequestParamsDraft23,
-        [DRAFT_VERSIONS.DRAFT_21]: redirectUriAuthorizationRequestParamsDraft21,
+        [SPEC_VERSIONS.V_1_0]: redirectUriAuthorizationRequestParamsDraft23,
+        [SPEC_VERSIONS.DRAFT_23]: redirectUriAuthorizationRequestParamsDraft23,
+        [SPEC_VERSIONS.DRAFT_21]: redirectUriAuthorizationRequestParamsDraft21,
     },
     [REQUEST_MODES.BY_VALUE]: {
-        [DRAFT_VERSIONS.V_1_0]: redirectAuthorizationRequestVersion1,
-        [DRAFT_VERSIONS.DRAFT_23]: redirectAuthorizationRequestDraft23,
-        [DRAFT_VERSIONS.DRAFT_21]: redirectAuthorizationRequestDraft21,
+        [SPEC_VERSIONS.V_1_0]: redirectAuthorizationRequestVersion1,
+        [SPEC_VERSIONS.DRAFT_23]: redirectAuthorizationRequestDraft23,
+        [SPEC_VERSIONS.DRAFT_21]: redirectAuthorizationRequestDraft21,
     }
 };
 

--- a/openid4vp-service/routes/verifierRoutes.js
+++ b/openid4vp-service/routes/verifierRoutes.js
@@ -6,7 +6,7 @@ const {
     ContentTypes,
     REQUEST_MODES,
     REQUEST_SIGNING_SUPPORT_MODES,
-    DRAFT_VERSIONS,
+    SPEC_VERSIONS,
     ResponseModes,
     baseUrl,
 } = require('../constants');
@@ -28,23 +28,44 @@ function createUrlWithParams(params) {
     return `${baseUrl}?${paramStrings.join('&')}`;
 }
 
-function buildRequestUri(baseUrl, clientIdScheme, draftVersion, responseMode, sessionId) {
-    const requestUri = new URL(`${baseUrl}/verifier/get-auth-request-obj/${sessionId}/${clientIdScheme}`);
-    requestUri.searchParams.set('draft', draftVersion);
+function buildRequestUri(baseUrl, clientIdPrefix, specVersion, responseMode, sessionId) {
+    const requestUri = new URL(`${baseUrl}/verifier/get-auth-request-obj/${sessionId}/${clientIdPrefix}`);
+    requestUri.searchParams.set('spec', specVersion);
     requestUri.searchParams.set('response_mode', responseMode);
     return requestUri.toString();
 }
 
-function isSupportedDraftVersion(draftVersion) {
-    return Object.values(DRAFT_VERSIONS).includes(draftVersion);
+function isSupportedSpecVersion(specVersion) {
+    return Object.values(SPEC_VERSIONS).includes(specVersion);
 }
 
-function updateVpRequest(inputData, responseMode, draftVersion, byReferenceMode = false) {
+// Normalize client_id_prefix input and validate spec version compatibility
+function normalizeClientIdPrefix(clientIdPrefixInput, currentSpecVersion) {
+    let normalizedPrefix = clientIdPrefixInput;
+    let specVersion = currentSpecVersion ?? SPEC_VERSIONS.V_1_0;
+
+    if (clientIdPrefixInput === "did") {
+        // "did" MUST be with draft-23 spec version
+        normalizedPrefix = "decentralized identifier";
+        if (specVersion !== SPEC_VERSIONS.DRAFT_23) {
+            throw new Error(`Bad Request: client_id_prefix "did" is only compatible with spec version "${SPEC_VERSIONS.DRAFT_23}", but "${specVersion}" was provided`);
+        }
+    } else if (clientIdPrefixInput === "decentralized_identifier") {
+        // "decentralized_identifier" MUST be with version-1.0 spec version
+        if (specVersion !== SPEC_VERSIONS.V_1_0) {
+            throw new Error(`Bad Request: client_id_prefix "decentralized_identifier" is only compatible with spec version "${SPEC_VERSIONS.V_1_0}", but "${specVersion}" was provided`);
+        }
+    }
+
+    return { normalizedPrefix, specVersion };
+}
+
+function updateVpRequest(inputData, responseMode, specVersion, byReferenceMode = false) {
     const updatedData = JSON.parse(JSON.stringify(inputData));
 
     updatedData.response_mode = responseMode;
 
-    const verifierMetadata = getVerifierMetadata(responseMode, draftVersion);
+    const verifierMetadata = getVerifierMetadata(responseMode, specVersion);
 
     if (byReferenceMode) {
         updatedData.client_metadata = verifierMetadata;
@@ -106,8 +127,11 @@ function registerVerifierRoutes(app, deps) {
         sessionId = null
     ) => {
         try {
-            const { client_id_scheme } = req.params;
-            const draftVersion = req.query.draft;
+            // Normalize client_id_prefix and validate spec version compatibility
+            const { normalizedPrefix, specVersion: normalizedSpecVersion } = normalizeClientIdPrefix(req.params.client_id_prefix, req.query.spec);
+            
+            let client_id_prefix = normalizedPrefix;
+            let specVersion = normalizedSpecVersion;
             const responseMode = req.query.response_mode || 'direct_post';
             const resolvedOverrides = resolveOverrides(req, providedDcqlQuery, providedPresentationDefinition);
             if (resolvedOverrides.errorMessage) {
@@ -117,33 +141,33 @@ function registerVerifierRoutes(app, deps) {
             const dcqlOverride = resolvedOverrides.dcqlOverride;
             const presentationDefinitionOverride = resolvedOverrides.presentationDefinitionOverride;
 
-            if (!draftVersion) {
-                res.status(400).send('Bad Request: draft parameter is required');
+            if (!specVersion) {
+                res.status(400).send('Bad Request: spec parameter is required');
                 return;
             }
 
-            if (!isSupportedDraftVersion(draftVersion)) {
-                res.status(400).send(`Bad Request: Unsupported draft version ${draftVersion}`);
+            if (!isSupportedSpecVersion(specVersion)) {
+                res.status(400).send(`Bad Request: Unsupported spec version ${specVersion}`);
                 return;
             }
 
-            const finalAuthRequestMapElement = finalAuthRequestMap[client_id_scheme];
+            const finalAuthRequestMapElement = finalAuthRequestMap[client_id_prefix];
 
             if (!finalAuthRequestMapElement?.[REQUEST_SIGNING_SUPPORT_MODES.SIGNED_REQUEST_SUPPORTED]) {
-                res.status(400).send(`Bad Request: ${client_id_scheme} does not support signed request, so by_reference mode is not possible`);
+                res.status(400).send(`Bad Request: ${client_id_prefix} does not support signed request, so by_reference mode is not possible`);
                 return;
             }
 
             let inputData = updateVpRequest(
-                finalAuthRequestMapElement?.[REQUEST_MODES.BY_VALUE]?.[draftVersion],
+                finalAuthRequestMapElement?.[REQUEST_MODES.BY_VALUE]?.[specVersion],
                 responseMode,
-                draftVersion,
+                specVersion,
                 true
             );
 
             inputData = applyDraftOverrides({
                 inputData,
-                draftVersion,
+                specVersion,
                 dcqlOverride,
                 presentationDefinitionOverride,
                 defaultDcqlQuery,
@@ -154,8 +178,8 @@ function registerVerifierRoutes(app, deps) {
 
             if (!inputData) {
                 console.error('Error generating JWT:', 'Provided combination is not supported - ', {
-                    client_id_scheme,
-                    draftVersion,
+                    client_id_prefix,
+                    specVersion,
                 });
                 res.status(400).send(providedCombinationIsNotSupported);
                 return;
@@ -177,12 +201,16 @@ function registerVerifierRoutes(app, deps) {
     };
 
     const generateQrCode = async (req, res) => {
-        const { client_id_scheme: pathClientIdScheme, request_mode: pathRequestMode } = req.params;
-        const bodyClientIdScheme = req.body?.client_id_scheme;
+        const { client_id_prefix: pathClientIdPrefix, request_mode: pathRequestMode } = req.params;
+        const bodyClientIdPrefix = req.body?.client_id_prefix;
         const bodyRequestMode = req.body?.request_mode;
-        const client_id_scheme = pathClientIdScheme || bodyClientIdScheme;
+        let client_id_prefix = pathClientIdPrefix || bodyClientIdPrefix;
         const request_mode = pathRequestMode || bodyRequestMode;
-        let draftVersion = req.query.draft ?? "version-1.0";
+
+        const { normalizedPrefix, specVersion: normalizedSpecVersion } = normalizeClientIdPrefix(client_id_prefix, req.query.spec);
+
+        client_id_prefix = normalizedPrefix;
+        let specVersion = normalizedSpecVersion;
         const signedValue = req.method === 'POST' ? req.body?.signed : req.query.signed;
         const signed = signedValue === true || signedValue === 'true';
         const responseMode = (req.method === 'POST' ? req.body?.response_mode : req.query.response_mode) || 'direct_post';
@@ -196,17 +224,17 @@ function registerVerifierRoutes(app, deps) {
         const dcqlQueryOverride = resolvedOverrides.dcqlOverride;
         const presentationDefinitionOverride = resolvedOverrides.presentationDefinitionOverride;
 
-        if (!draftVersion) {
-            draftVersion = DRAFT_VERSIONS.V_1_0;
+        if (!specVersion) {
+            specVersion = SPEC_VERSIONS.V_1_0;
         }
 
-        if (!isSupportedDraftVersion(draftVersion)) {
-            res.status(400).send(`Bad Request: Unsupported draft version ${draftVersion}`);
+        if (!isSupportedSpecVersion(specVersion)) {
+            res.status(400).send(`Bad Request: Unsupported spec version ${specVersion}`);
             return;
         }
 
-        if (!client_id_scheme || !request_mode) {
-            res.status(400).send('Bad Request: client_id_scheme and request_mode are required');
+        if (!client_id_prefix || !request_mode) {
+            res.status(400).send('Bad Request: client_id_prefix and request_mode are required');
             return;
         }
 
@@ -220,28 +248,28 @@ function registerVerifierRoutes(app, deps) {
             console.warn('Failed to persist VP request session data, continuing without stored overrides:', error.message);
         }
 
-        const finalAuthRequestMapElement = finalAuthRequestMap[client_id_scheme];
+        const finalAuthRequestMapElement = finalAuthRequestMap[client_id_prefix];
 
         if (!finalAuthRequestMapElement) {
-            console.error('Error generating QR code:', `Unsupported client_id_scheme ${client_id_scheme}`);
-            res.status(400).send(`Bad Request: Unsupported client_id_scheme ${client_id_scheme}`);
+            console.error('Error generating QR code:', `Unsupported client_id_prefix ${client_id_prefix}`);
+            res.status(400).send(`Bad Request: Unsupported client_id_prefix ${client_id_prefix}`);
             return;
         }
 
         if (request_mode === REQUEST_MODES.BY_REFERENCE) {
             if (!finalAuthRequestMapElement[REQUEST_SIGNING_SUPPORT_MODES.SIGNED_REQUEST_SUPPORTED]) {
-                const errorMessage = `Bad Request: ${client_id_scheme} does not support signed request, so by_reference mode is not possible`;
+                const errorMessage = `Bad Request: ${client_id_prefix} does not support signed request, so by_reference mode is not possible`;
                 console.error('Error generating QR code:', errorMessage);
                 res.status(400).send(errorMessage);
                 return;
             }
 
-            const inputData = finalAuthRequestMapElement?.[request_mode]?.[draftVersion];
+            const inputData = finalAuthRequestMapElement?.[request_mode]?.[specVersion];
             if (!inputData) {
                 console.error('Error generating QR code:', 'Provided combination is not supported - ', {
-                    client_id_scheme,
+                    client_id_prefix: client_id_prefix,
                     request_mode,
-                    draftVersion,
+                    specVersion,
                 });
                 res.status(400).send(providedCombinationIsNotSupported);
                 return;
@@ -249,19 +277,19 @@ function registerVerifierRoutes(app, deps) {
 
             const updatedData = {
                 ...inputData,
-                request_uri: buildRequestUri(baseUrl, client_id_scheme, draftVersion, responseMode, sessionId),
+                request_uri: buildRequestUri(baseUrl, client_id_prefix, specVersion, responseMode, sessionId),
             };
 
             await generateQrCodeResponse(QRCode, updatedData, res);
             return;
         }
 
-        let inputData = finalAuthRequestMapElement?.[request_mode]?.[draftVersion];
+        let inputData = finalAuthRequestMapElement?.[request_mode]?.[specVersion];
         if (!inputData) {
             console.error('Error generating QR code:', 'Provided combination is not supported - ', {
-                client_id_scheme,
+                client_id_prefix: client_id_prefix,
                 request_mode,
-                draftVersion,
+                specVersion,
             });
 
             res.status(400).send(providedCombinationIsNotSupported);
@@ -270,7 +298,7 @@ function registerVerifierRoutes(app, deps) {
 
         inputData = applyDraftOverrides({
             inputData,
-            draftVersion,
+            specVersion,
             dcqlOverride: dcqlQueryOverride,
             presentationDefinitionOverride,
             defaultDcqlQuery,
@@ -281,25 +309,25 @@ function registerVerifierRoutes(app, deps) {
 
         if (signed) {
             if (!finalAuthRequestMapElement[REQUEST_SIGNING_SUPPORT_MODES.SIGNED_REQUEST_SUPPORTED]) {
-                console.error('Error generating QR code:', `${client_id_scheme} does not support signed request`);
+                console.error('Error generating QR code:', `${client_id_prefix} does not support signed request`);
 
-                res.status(400).send(`Bad Request: ${client_id_scheme} does not support ${request_mode} mode with signed request\nAction: try switching to unsigned request`);
+                res.status(400).send(`Bad Request: ${client_id_prefix} does not support ${request_mode} mode with signed request\nAction: try switching to unsigned request`);
                 return;
             }
 
-            inputData = updateVpRequest(inputData, responseMode, draftVersion);
+            inputData = updateVpRequest(inputData, responseMode, specVersion);
 
             const clientId = inputData.client_id;
             const request = await createJWT(inputData);
 
             inputData = { client_id: clientId, request };
         } else if (!finalAuthRequestMapElement[REQUEST_SIGNING_SUPPORT_MODES.UNSIGNED_REQUEST_SUPPORTED]) {
-            console.error('Error generating QR code:', `${client_id_scheme} does not support unsigned request`);
+            console.error('Error generating QR code:', `${client_id_prefix} does not support unsigned request`);
 
-            res.status(400).send(`Bad Request: ${client_id_scheme} does not support unsigned request in ${request_mode} mode\nAction: try switching to signed request`);
+            res.status(400).send(`Bad Request: ${client_id_prefix} does not support unsigned request in ${request_mode} mode\nAction: try switching to signed request`);
             return;
         } else {
-            inputData = updateVpRequest(inputData, responseMode, draftVersion);
+            inputData = updateVpRequest(inputData, responseMode, specVersion);
         }
 
         await generateQrCodeResponse(QRCode, inputData, res);
@@ -335,36 +363,36 @@ function registerVerifierRoutes(app, deps) {
     });
 
     // API for actual authorization request object
-    // client_id_scheme: pre-registered | redirect_uri | did
-    // API: /verifier/get-auth-request-obj/:sessionId/:client_id_scheme
+    // client_id_prefix: pre-registered | redirect_uri | did (requires draft-23) | decentralized_identifier (requires version-1.0)
+    // API: /verifier/get-auth-request-obj/:sessionId/:client_id_prefix
     
-    // Uses sessionId created during /verifier/:client_id_scheme/:request_mode request creation.
+    // Uses sessionId created during /verifier/:client_id_prefix/:request_mode request creation.
     // Resolves session-scoped overrides and returns a signed/processed request object.
-    app.get('/verifier/get-auth-request-obj/:sessionId/:client_id_scheme', handleSessionRequestUri);
-    app.post('/verifier/get-auth-request-obj/:sessionId/:client_id_scheme', handleSessionRequestUri);
+    app.get('/verifier/get-auth-request-obj/:sessionId/:client_id_prefix', handleSessionRequestUri);
+    app.post('/verifier/get-auth-request-obj/:sessionId/:client_id_prefix', handleSessionRequestUri);
 
-    // API to generate QR codes for different client_id schemes and request modes
-    // API: /verifier/:client_id_scheme/:request_mode?draft=<draft_version>&signed=true|false&response_mode=<response_mode>
-    // client_id_scheme: pre-registered | redirect_uri | did
+    // API to generate QR codes for different client_id prefixes and request modes
+    // API: /verifier/:client_id_prefix/:request_mode?spec=<spec_version>&signed=true|false&response_mode=<response_mode>
+    // client_id_prefix: pre-registered | redirect_uri | did (requires draft-23) | decentralized_identifier (requires version-1.0)
     // request_mode: by_value | by_reference
     // response_mode: direct_post | direct_post.jwt
-    app.get('/verifier/:client_id_scheme/:request_mode', async (req, res) => {
+    app.get('/verifier/:client_id_prefix/:request_mode', async (req, res) => {
         await generateQrCode(req, res);
     });
 
-    // API: POST /verifier/:client_id_scheme/:request_mode
+    // API: POST /verifier/:client_id_prefix/:request_mode
     // Responsibility:
     // - Builds an authorization request for the selected verifier mode and returns QR response payload.
     // - Applies optional request overrides (dcql_query / presentation_definition) and signing options.
     // - Returns `{ qrCodeData, qrData, inputData }` on success, or a 4xx/5xx error message on failure.
     // Request params:
-    // - path.client_id_scheme: pre-registered | redirect_uri | did
+    // - path.client_id_prefix: pre-registered | redirect_uri | did (requires draft-23) | decentralized_identifier (requires version-1.0)
     // - path.request_mode: by_value | by_reference
-    // - query.draft: draft version (optional, defaults to version-1.0)
+    // - query.spec: spec version (optional; if not provided, defaults to version-1.0
     // Request body (optional):
     // - signed: true | false
     // - response_mode: direct_post | direct_post.jwt
-    // - dcql_query: object (draft version-1.0)
+    // - dcql_query: object (spec version-1.0)
     // - presentation_definition: object (non-version-1.0 drafts)
     // Response:
     // - 200 application/json:
@@ -375,7 +403,7 @@ function registerVerifierRoutes(app, deps) {
     //   }
     // - 400 text/plain for invalid combinations/unsupported params/oversized QR payload.
     // - 500 text/plain for unexpected server errors.
-    app.post('/verifier/:client_id_scheme/:request_mode', async (req, res) => {
+    app.post('/verifier/:client_id_prefix/:request_mode', async (req, res) => {
         await generateQrCode(req, res);
     });
 }

--- a/openid4vp-service/routes/verifierRoutes.js
+++ b/openid4vp-service/routes/verifierRoutes.js
@@ -46,7 +46,7 @@ function normalizeClientIdPrefix(clientIdPrefixInput, currentSpecVersion) {
 
     if (clientIdPrefixInput === "did") {
         // "did" MUST be with draft-23 spec version
-        normalizedPrefix = "decentralized identifier";
+        normalizedPrefix = "decentralized_identifier";
         if (specVersion !== SPEC_VERSIONS.DRAFT_23) {
             throw new Error(`Bad Request: client_id_prefix "did" is only compatible with spec version "${SPEC_VERSIONS.DRAFT_23}", but "${specVersion}" was provided`);
         }
@@ -201,6 +201,7 @@ function registerVerifierRoutes(app, deps) {
         const bodyClientIdPrefix = req.body?.client_id_prefix;
         const bodyRequestMode = req.body?.request_mode;
         let client_id_prefix = pathClientIdPrefix || bodyClientIdPrefix;
+        let originalClientIdPrefix = client_id_prefix
         const request_mode = pathRequestMode || bodyRequestMode;
 
         const { normalizedPrefix, specVersion: normalizedSpecVersion } = normalizeClientIdPrefix(client_id_prefix, req.query.spec);
@@ -273,7 +274,7 @@ function registerVerifierRoutes(app, deps) {
 
             const updatedData = {
                 ...inputData,
-                request_uri: buildRequestUri(baseUrl, client_id_prefix, specVersion, responseMode, sessionId),
+                request_uri: buildRequestUri(baseUrl, originalClientIdPrefix, specVersion, responseMode, sessionId),
             };
 
             await generateQrCodeResponse(QRCode, updatedData, res);

--- a/openid4vp-service/routes/verifierRoutes.js
+++ b/openid4vp-service/routes/verifierRoutes.js
@@ -44,11 +44,7 @@ function updateVpRequest(inputData, responseMode, draftVersion, byReferenceMode 
 
     updatedData.response_mode = responseMode;
 
-    const responseModeEnum = responseMode === 'direct_post.jwt'
-        ? ResponseModes.DIRECT_POST_JWT
-        : ResponseModes.DIRECT_POST;
-
-    const verifierMetadata = getVerifierMetadata(responseModeEnum, draftVersion);
+    const verifierMetadata = getVerifierMetadata(responseMode, draftVersion);
 
     if (byReferenceMode) {
         updatedData.client_metadata = verifierMetadata;
@@ -186,7 +182,7 @@ function registerVerifierRoutes(app, deps) {
         const bodyRequestMode = req.body?.request_mode;
         const client_id_scheme = pathClientIdScheme || bodyClientIdScheme;
         const request_mode = pathRequestMode || bodyRequestMode;
-        let draftVersion = req.query.draft;
+        let draftVersion = req.query.draft ?? "version-1.0";
         const signedValue = req.method === 'POST' ? req.body?.signed : req.query.signed;
         const signed = signedValue === true || signedValue === 'true';
         const responseMode = (req.method === 'POST' ? req.body?.response_mode : req.query.response_mode) || 'direct_post';

--- a/openid4vp-service/routes/verifierRoutes.js
+++ b/openid4vp-service/routes/verifierRoutes.js
@@ -141,11 +141,6 @@ function registerVerifierRoutes(app, deps) {
             const dcqlOverride = resolvedOverrides.dcqlOverride;
             const presentationDefinitionOverride = resolvedOverrides.presentationDefinitionOverride;
 
-            if (!specVersion) {
-                res.status(400).send('Bad Request: spec parameter is required');
-                return;
-            }
-
             if (!isSupportedSpecVersion(specVersion)) {
                 res.status(400).send(`Bad Request: Unsupported spec version ${specVersion}`);
                 return;
@@ -158,12 +153,13 @@ function registerVerifierRoutes(app, deps) {
                 return;
             }
 
-            let inputData = updateVpRequest(
-                finalAuthRequestMapElement?.[REQUEST_MODES.BY_VALUE]?.[specVersion],
-                responseMode,
-                specVersion,
-                true
-            );
+            const selectedTemplate = finalAuthRequestMapElement?.[REQUEST_MODES.BY_VALUE]?.[specVersion];
+            if (!selectedTemplate) {
+                console.error('Error generating JWT:', 'Provided combination is not supported - ', { client_id_prefix, specVersion });
+                res.status(400).send(providedCombinationIsNotSupported);
+                return;
+            }
+            let inputData = updateVpRequest(selectedTemplate, responseMode, specVersion, true);
 
             inputData = applyDraftOverrides({
                 inputData,

--- a/openid4vp-service/services/requestOverrides.js
+++ b/openid4vp-service/services/requestOverrides.js
@@ -50,8 +50,8 @@ function isValidPresentationDefinitionOverride(pd) {
     return !!pd && typeof pd === 'object' && !Array.isArray(pd);
 }
 
-function applyPresentationDefinitionOverride(inputData, draftVersion, presentationDefinitionOverride, defaultPresentationDefinition) {
-    if (!inputData || draftVersion === SPEC_VERSIONS.V_1_0 || !('presentation_definition' in inputData)) {
+function applyPresentationDefinitionOverride(inputData, specVersion, presentationDefinitionOverride, defaultPresentationDefinition) {
+    if (!inputData || specVersion === SPEC_VERSIONS.V_1_0 || !('presentation_definition' in inputData)) {
         return inputData;
     }
 
@@ -64,8 +64,8 @@ function applyPresentationDefinitionOverride(inputData, draftVersion, presentati
     return updatedInputData;
 }
 
-function applyDcqlQueryOverride(inputData, draftVersion, dcqlOverride, defaultDcqlQuery) {
-    if (!inputData || draftVersion !== SPEC_VERSIONS.V_1_0 || !('dcql_query' in inputData)) {
+function applyDcqlQueryOverride(inputData, specVersion, dcqlOverride, defaultDcqlQuery) {
+    if (!inputData || specVersion !== SPEC_VERSIONS.V_1_0 || !('dcql_query' in inputData)) {
         return inputData;
     }
 

--- a/openid4vp-service/services/requestOverrides.js
+++ b/openid4vp-service/services/requestOverrides.js
@@ -1,4 +1,4 @@
-const { DRAFT_VERSIONS } = require('../constants');
+const { SPEC_VERSIONS } = require('../constants');
 
 function extractDcqlQueryOverride(req) {
     if (req.body && req.body.dcql_query !== undefined) {
@@ -51,7 +51,7 @@ function isValidPresentationDefinitionOverride(pd) {
 }
 
 function applyPresentationDefinitionOverride(inputData, draftVersion, presentationDefinitionOverride, defaultPresentationDefinition) {
-    if (!inputData || draftVersion === DRAFT_VERSIONS.V_1_0 || !('presentation_definition' in inputData)) {
+    if (!inputData || draftVersion === SPEC_VERSIONS.V_1_0 || !('presentation_definition' in inputData)) {
         return inputData;
     }
 
@@ -65,7 +65,7 @@ function applyPresentationDefinitionOverride(inputData, draftVersion, presentati
 }
 
 function applyDcqlQueryOverride(inputData, draftVersion, dcqlOverride, defaultDcqlQuery) {
-    if (!inputData || draftVersion !== DRAFT_VERSIONS.V_1_0 || !('dcql_query' in inputData)) {
+    if (!inputData || draftVersion !== SPEC_VERSIONS.V_1_0 || !('dcql_query' in inputData)) {
         return inputData;
     }
 

--- a/openid4vp-service/services/verifierFlow.js
+++ b/openid4vp-service/services/verifierFlow.js
@@ -45,7 +45,7 @@ function resolveOverrides(req, providedDcqlQuery = undefined, providedPresentati
 
 function applyDraftOverrides({
     inputData,
-    draftVersion,
+    specVersion,
     dcqlOverride,
     presentationDefinitionOverride,
     defaultDcqlQuery,
@@ -53,13 +53,13 @@ function applyDraftOverrides({
     baseUrl,
     sessionId,
 }) {
-    if (draftVersion === SPEC_VERSIONS.V_1_0) {
-        return applyDcqlQueryOverride(inputData, draftVersion, dcqlOverride, defaultDcqlQuery);
+    if (specVersion === SPEC_VERSIONS.V_1_0) {
+        return applyDcqlQueryOverride(inputData, specVersion, dcqlOverride, defaultDcqlQuery);
     }
 
     const updatedInputData = applyPresentationDefinitionOverride(
         inputData,
-        draftVersion,
+        specVersion,
         presentationDefinitionOverride,
         defaultPresentationDefinition
     );

--- a/openid4vp-service/services/verifierFlow.js
+++ b/openid4vp-service/services/verifierFlow.js
@@ -1,4 +1,4 @@
-const { DRAFT_VERSIONS } = require('../constants');
+const { SPEC_VERSIONS: SPEC_VERSIONS } = require('../constants');
 const {
     extractDcqlQueryOverride,
     isValidDcqlOverride,
@@ -53,7 +53,7 @@ function applyDraftOverrides({
     baseUrl,
     sessionId,
 }) {
-    if (draftVersion === DRAFT_VERSIONS.V_1_0) {
+    if (draftVersion === SPEC_VERSIONS.V_1_0) {
         return applyDcqlQueryOverride(inputData, draftVersion, dcqlOverride, defaultDcqlQuery);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded OpenID4VP presentation request definition examples with additional credential types and constraints.
  * Added OpenID4VP request configuration controls for PDI flow (spec version, response mode, request mode, signed requests).
* **Improvements**
  * Enhanced SD-JWT issuance to improve holder confirmation handling (including for additional non-v1 formats) and refined payload disclosure behavior.
  * Updated OpenID4VP verifier/QR flows to use spec-version and client-id-prefix terminology and behavior.
  * Refreshed issuer metadata/config IDs for the farmer credential.
* **Bug Fixes**
  * Updated verifier VP response messaging to indicate success.
* **Documentation**
  * Updated terminology and API/query parameter naming to “client id prefix” and “spec version.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->